### PR TITLE
macOS: make the backend actually work on hardware (launch crash, TIS threading, event tap, emitter tagging)

### DIFF
--- a/crates/poltertype-app/src/autostart.rs
+++ b/crates/poltertype-app/src/autostart.rs
@@ -5,11 +5,13 @@
 //! where the checkbox becomes real.
 //!
 //! * **macOS** — a per-user LaunchAgent at
-//!   `~/Library/LaunchAgents/org.poltertype.app.plist`. We rewrite
-//!   it when the exe path changed (an update replaced / moved the
-//!   .app) and delete it when the toggle is off. Modern macOS shows
-//!   a one-time "login item added" notification for this; that is
-//!   the system working as intended.
+//!   `~/Library/LaunchAgents/<APP_ID>.plist`
+//!   (`dev.opensource.poltertype.plist`). We rewrite it when the exe
+//!   path changed (an update replaced / moved the .app), register it
+//!   with launchd immediately so coverage starts without a relogin,
+//!   and delete it when the toggle is off. Modern macOS shows a
+//!   one-time "login item added" notification for this; that is the
+//!   system working as intended.
 //! * **Windows / Linux** — still unimplemented (same as before):
 //!   the sync is a no-op there.
 
@@ -110,23 +112,28 @@ mod imp {
         };
         let body = plist_body(&exe);
 
-        // Idempotent: don't touch the file (and launchd) when the
-        // desired state is already on disk.
+        // Rewrite the file when its contents drifted (the exe path
+        // moved under an update, an older build wrote a different
+        // label, …). When it's already byte-identical we skip the
+        // write — but NOT the launchd registration below: a plist can
+        // be on disk yet unregistered (written by an older build, or
+        // the machine hasn't been relogged since), and answering only
+        // "is the file right" would leave the job dormant until next
+        // login.
         let current = std::fs::read_to_string(&path).unwrap_or_default();
-        if current == body {
-            return;
-        }
-        if let Some(dir) = path.parent() {
-            if let Err(e) = std::fs::create_dir_all(dir) {
-                warn!(?e, ?dir, "could not create LaunchAgents dir");
+        if current != body {
+            if let Some(dir) = path.parent() {
+                if let Err(e) = std::fs::create_dir_all(dir) {
+                    warn!(?e, ?dir, "could not create LaunchAgents dir");
+                    return;
+                }
+            }
+            if let Err(e) = std::fs::write(&path, &body) {
+                warn!(?e, ?path, "could not write LaunchAgent plist");
                 return;
             }
+            debug!(?path, "autostart enabled: LaunchAgent written");
         }
-        if let Err(e) = std::fs::write(&path, &body) {
-            warn!(?e, ?path, "could not write LaunchAgent plist");
-            return;
-        }
-        debug!(?path, "autostart enabled: LaunchAgent written");
 
         // Register right away so the user doesn't need a relogin to
         // get coverage from this session on. `bootstrap` on an

--- a/crates/poltertype-app/src/autostart.rs
+++ b/crates/poltertype-app/src/autostart.rs
@@ -33,7 +33,9 @@ mod imp {
     /// Minimal XML escaping for the program path (`&` is legal in
     /// file names).
     fn xml_escape(s: &str) -> String {
-        s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+        s.replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
     }
 
     fn plist_body(exe: &Path) -> String {
@@ -61,7 +63,9 @@ mod imp {
 
     fn launchctl(args: &[&str]) {
         match std::process::Command::new("launchctl").args(args).status() {
-            Ok(st) if !st.success() => debug!(?args, status = ?st, "launchctl: non-zero exit (fine if job was (un)loaded already)"),
+            Ok(st) if !st.success() => {
+                debug!(?args, status = ?st, "launchctl: non-zero exit (fine if job was (un)loaded already)")
+            }
             Ok(_) => {}
             Err(e) => warn!(?e, ?args, "could not run launchctl"),
         }

--- a/crates/poltertype-app/src/autostart.rs
+++ b/crates/poltertype-app/src/autostart.rs
@@ -1,0 +1,150 @@
+//! Apply `[general].autostart` to the OS autostart mechanism.
+//!
+//! The setting existed long before any platform honoured it — the
+//! Settings GUI checkbox only edited `config.toml`. This module is
+//! where the checkbox becomes real.
+//!
+//! * **macOS** — a per-user LaunchAgent at
+//!   `~/Library/LaunchAgents/org.poltertype.app.plist`. We rewrite
+//!   it when the exe path changed (an update replaced / moved the
+//!   .app) and delete it when the toggle is off. Modern macOS shows
+//!   a one-time "login item added" notification for this; that is
+//!   the system working as intended.
+//! * **Windows / Linux** — still unimplemented (same as before):
+//!   the sync is a no-op there.
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use std::path::{Path, PathBuf};
+
+    use tracing::{debug, warn};
+
+    use crate::consts::APP_ID;
+
+    fn plist_path() -> Option<PathBuf> {
+        let home = std::env::var_os("HOME")?;
+        Some(
+            PathBuf::from(home)
+                .join("Library/LaunchAgents")
+                .join(format!("{APP_ID}.plist")),
+        )
+    }
+
+    /// Minimal XML escaping for the program path (`&` is legal in
+    /// file names).
+    fn xml_escape(s: &str) -> String {
+        s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+    }
+
+    fn plist_body(exe: &Path) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{APP_ID}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+</dict>
+</plist>
+"#,
+            xml_escape(&exe.display().to_string())
+        )
+    }
+
+    fn launchctl(args: &[&str]) {
+        match std::process::Command::new("launchctl").args(args).status() {
+            Ok(st) if !st.success() => debug!(?args, status = ?st, "launchctl: non-zero exit (fine if job was (un)loaded already)"),
+            Ok(_) => {}
+            Err(e) => warn!(?e, ?args, "could not run launchctl"),
+        }
+    }
+
+    /// Numeric uid for the `gui/<uid>` launchd domain, without
+    /// touching libc (the crate forbids unsafe code).
+    fn uid() -> Option<String> {
+        let out = std::process::Command::new("id").arg("-u").output().ok()?;
+        let s = String::from_utf8(out.stdout).ok()?.trim().to_owned();
+        (!s.is_empty()).then_some(s)
+    }
+
+    pub fn sync(enabled: bool) {
+        let Some(path) = plist_path() else {
+            warn!("could not resolve ~/Library/LaunchAgents; autostart unchanged");
+            return;
+        };
+
+        if !enabled {
+            if path.exists() {
+                // Unregister the running job first; bootout on an
+                // already-absent job errors, which is fine.
+                if let Some(uid) = uid() {
+                    launchctl(&["bootout", &format!("gui/{uid}/{APP_ID}")]);
+                }
+                if let Err(e) = std::fs::remove_file(&path) {
+                    warn!(?e, ?path, "could not remove LaunchAgent plist");
+                } else {
+                    debug!(?path, "autostart disabled: LaunchAgent removed");
+                }
+            }
+            return;
+        }
+
+        let exe = match std::env::current_exe() {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(?e, "could not resolve own exe; autostart unchanged");
+                return;
+            }
+        };
+        let body = plist_body(&exe);
+
+        // Idempotent: don't touch the file (and launchd) when the
+        // desired state is already on disk.
+        let current = std::fs::read_to_string(&path).unwrap_or_default();
+        if current == body {
+            return;
+        }
+        if let Some(dir) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(dir) {
+                warn!(?e, ?dir, "could not create LaunchAgents dir");
+                return;
+            }
+        }
+        if let Err(e) = std::fs::write(&path, &body) {
+            warn!(?e, ?path, "could not write LaunchAgent plist");
+            return;
+        }
+        debug!(?path, "autostart enabled: LaunchAgent written");
+
+        // Register right away so the user doesn't need a relogin to
+        // get coverage from this session on. `bootstrap` on an
+        // already-registered job errors — harmless.
+        if let Some(uid) = uid() {
+            let target = format!("gui/{uid}");
+            launchctl(&["bootout", &format!("{target}/{APP_ID}")]);
+            launchctl(&["bootstrap", &target, &path.to_string_lossy()]);
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+mod imp {
+    pub fn sync(_enabled: bool) {
+        // Not implemented on this platform yet — the checkbox keeps
+        // editing config.toml only, same contract as before.
+    }
+}
+
+/// Make the OS autostart entry match the setting. Cheap and
+/// idempotent — call at startup and after every settings reload.
+pub(crate) fn sync(enabled: bool) {
+    imp::sync(enabled);
+}

--- a/crates/poltertype-app/src/main.rs
+++ b/crates/poltertype-app/src/main.rs
@@ -103,7 +103,26 @@ fn main() -> Result<()> {
     let _log_guard = init_tracing();
     info!(version = env!("CARGO_PKG_VERSION"), "{APP_NAME} starting");
 
-    let instance = SingleInstance::new(APP_ID).context("create single-instance lock")?;
+    // On macOS the `single-instance` crate treats the id as a file
+    // path and flocks it. A bare id lands in the process cwd — which
+    // is `/` (read-only system volume) when the app is launched via
+    // Finder / `open`, so startup died with "Read-only file system".
+    // Give it an absolute path under the per-user config dir instead.
+    // On Linux (abstract socket) and Windows (named mutex) the id is
+    // not a path, so keep it untouched there.
+    #[cfg(target_os = "macos")]
+    let lock_id: String = {
+        let dir = poltertype_core::settings::SettingsStore::project_dirs()
+            .map(|d| d.config_dir().to_path_buf())
+            .unwrap_or_else(|_| std::env::temp_dir());
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            warn!(?e, ?dir, "could not create config dir for instance lock");
+        }
+        dir.join("poltertype.lock").to_string_lossy().into_owned()
+    };
+    #[cfg(not(target_os = "macos"))]
+    let lock_id: &str = APP_ID;
+    let instance = SingleInstance::new(&lock_id).context("create single-instance lock")?;
     if !instance.is_single() {
         warn!("another instance is already running, exiting");
         return Ok(());

--- a/crates/poltertype-app/src/main.rs
+++ b/crates/poltertype-app/src/main.rs
@@ -118,7 +118,9 @@ fn main() -> Result<()> {
         if let Err(e) = std::fs::create_dir_all(&dir) {
             warn!(?e, ?dir, "could not create config dir for instance lock");
         }
-        dir.join("poltertype.lock").to_string_lossy().into_owned()
+        dir.join(format!("{APP_ID}.lock"))
+            .to_string_lossy()
+            .into_owned()
     };
     #[cfg(not(target_os = "macos"))]
     let lock_id: &str = APP_ID;

--- a/crates/poltertype-app/src/main.rs
+++ b/crates/poltertype-app/src/main.rs
@@ -18,6 +18,7 @@
 mod icon_render;
 mod settings_ui;
 
+mod autostart;
 mod bridges;
 mod consts;
 mod detectors;
@@ -139,6 +140,11 @@ fn main() -> Result<()> {
         }
     };
     info!(path = ?settings.path(), "settings loaded");
+
+    // Make the OS autostart entry match the setting (macOS
+    // LaunchAgent; no-op elsewhere for now). Runs on every startup so
+    // a config edited by hand takes effect too.
+    autostart::sync(settings.snapshot().general.autostart);
 
     // ─── Layout switcher (built first so we can query active OS
     //                     layouts before loading the DB) ────────────

--- a/crates/poltertype-app/src/main.rs
+++ b/crates/poltertype-app/src/main.rs
@@ -368,7 +368,17 @@ fn main() -> Result<()> {
         .is_some_and(|l| l.backend_name() == "linux-wayland-evdev");
 
     // ─── Tao event loop + tray + global hotkeys ────────────────────
-    let event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
+    #[allow(unused_mut)]
+    let mut event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
+    #[cfg(target_os = "macos")]
+    {
+        // Tray-only app: LSUIElement alone is not enough — tao
+        // explicitly applies ActivationPolicy::Regular (its default)
+        // at startup, which puts us in the Dock anyway. Accessory
+        // keeps us out of the Dock and the Cmd+Tab switcher.
+        use tao::platform::macos::{ActivationPolicy, EventLoopExtMacOS};
+        event_loop.set_activation_policy(ActivationPolicy::Accessory);
+    }
 
     let menu = Menu::new();
     // Onboarding alert entry — present only when keyboard hooks

--- a/crates/poltertype-app/src/main.rs
+++ b/crates/poltertype-app/src/main.rs
@@ -124,7 +124,7 @@ fn main() -> Result<()> {
             .into_owned()
     };
     #[cfg(not(target_os = "macos"))]
-    let lock_id: &str = APP_ID;
+    let lock_id: String = APP_ID.to_owned();
     let instance = SingleInstance::new(&lock_id).context("create single-instance lock")?;
     if !instance.is_single() {
         warn!("another instance is already running, exiting");

--- a/crates/poltertype-app/src/settings_proc/spawn.rs
+++ b/crates/poltertype-app/src/settings_proc/spawn.rs
@@ -81,6 +81,11 @@ pub(crate) fn spawn_settings_ui(deps: SettingsCloseDeps) {
                 Err(e) => warn!(?e, "could not reload config.toml after settings UI exit"),
             }
 
+            // (1a) The autostart checkbox edits config.toml like any
+            // other setting; re-apply it to the OS now that the file
+            // is re-read.
+            crate::autostart::sync(deps.settings.snapshot().general.autostart);
+
             // (2) Global wordlist reload — same path as the tray
             // "Reload Settings" menu entry.
             let n = reload_user_dictionaries(&deps.dict_reload_handle);

--- a/crates/poltertype-app/src/settings_ui/helpers.rs
+++ b/crates/poltertype-app/src/settings_ui/helpers.rs
@@ -309,8 +309,44 @@ pub fn accept_modifiers_enable_keyboard(s: &str) -> bool {
     poltertype_core::engine::AcceptModifiers::parse(s).is_some()
 }
 
-/// Lone-modifier-only key presses (Ctrl, Shift, Alt, Cmd) shouldn't
-/// be captured as the hotkey itself — the user is mid-combination.
+/// Display form of a stored hotkey token for keycap chips. Config
+/// keeps the portable names (`Ctrl`, `Alt`, `Meta`); on macOS the
+/// chips use the platform's own glyphs (⌃ ⌥ ⇧ ⌘) and key symbols —
+/// those are the names printed on the user's keyboard.
+pub fn display_key_token(tok: &str) -> String {
+    #[cfg(target_os = "macos")]
+    {
+        match tok.to_ascii_lowercase().as_str() {
+            "ctrl" | "control" => "⌃".into(),
+            "alt" | "option" => "⌥".into(),
+            "shift" => "⇧".into(),
+            "meta" | "cmd" | "command" | "super" | "win" => "⌘".into(),
+            "backspace" => "⌫".into(),
+            "enter" | "return" => "↩".into(),
+            "tab" => "⇥".into(),
+            "esc" | "escape" => "⎋".into(),
+            "space" => "Space".into(),
+            "up" => "↑".into(),
+            "down" => "↓".into(),
+            "left" => "←".into(),
+            "right" => "→".into(),
+            _ => tok.to_owned(),
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        tok.to_owned()
+    }
+}
+
+/// Modifier list for prose hints, in the platform's vocabulary.
+#[cfg(target_os = "macos")]
+pub const MODIFIER_NAMES_PROSE: &str = "⌃ / ⌥ / ⇧ / ⌘";
+/// Modifier list for prose hints, in the platform's vocabulary.
+#[cfg(not(target_os = "macos"))]
+pub const MODIFIER_NAMES_PROSE: &str = "Ctrl / Alt / Shift / Meta";
+
+/// Lone-modifier-only key presses (Ctrl, Shift, Alt, Cmd) shouldn't/// be captured as the hotkey itself — the user is mid-combination.
 /// We filter them in the keyboard subscription so the captured combo
 /// is always `<modifier(s)>+<non-modifier-key>`.
 pub fn is_modifier_key(key: &Key) -> bool {

--- a/crates/poltertype-app/src/settings_ui/helpers.rs
+++ b/crates/poltertype-app/src/settings_ui/helpers.rs
@@ -339,7 +339,8 @@ pub fn display_key_token(tok: &str) -> String {
     }
 }
 
-/// Lone-modifier-only key presses (Ctrl, Shift, Alt, Cmd) shouldn't/// be captured as the hotkey itself — the user is mid-combination.
+/// Lone-modifier-only key presses (Ctrl, Shift, Alt, Cmd) shouldn't
+/// be captured as the hotkey itself — the user is mid-combination.
 /// We filter them in the keyboard subscription so the captured combo
 /// is always `<modifier(s)>+<non-modifier-key>`.
 pub fn is_modifier_key(key: &Key) -> bool {

--- a/crates/poltertype-app/src/settings_ui/helpers.rs
+++ b/crates/poltertype-app/src/settings_ui/helpers.rs
@@ -339,13 +339,6 @@ pub fn display_key_token(tok: &str) -> String {
     }
 }
 
-/// Modifier list for prose hints, in the platform's vocabulary.
-#[cfg(target_os = "macos")]
-pub const MODIFIER_NAMES_PROSE: &str = "⌃ / ⌥ / ⇧ / ⌘";
-/// Modifier list for prose hints, in the platform's vocabulary.
-#[cfg(not(target_os = "macos"))]
-pub const MODIFIER_NAMES_PROSE: &str = "Ctrl / Alt / Shift / Meta";
-
 /// Lone-modifier-only key presses (Ctrl, Shift, Alt, Cmd) shouldn't/// be captured as the hotkey itself — the user is mid-combination.
 /// We filter them in the keyboard subscription so the captured combo
 /// is always `<modifier(s)>+<non-modifier-key>`.

--- a/crates/poltertype-app/src/settings_ui/view.rs
+++ b/crates/poltertype-app/src/settings_ui/view.rs
@@ -290,6 +290,11 @@ impl SettingsApp {
             ))
             .push(tip(
                 b,
+                #[cfg(target_os = "macos")]
+                "Tip: capture refuses single-letter combinations and bare \
+                 keys — at least one of ⌃ / ⌥ / ⇧ / ⌘ is required. \
+                 Esc cancels capture without changing anything.",
+                #[cfg(not(target_os = "macos"))]
                 "Tip: capture refuses single-letter combinations and bare \
                  keys — at least one of Ctrl / Alt / Shift / Cmd is required. \
                  Esc cancels capture without changing anything.",
@@ -1050,6 +1055,10 @@ impl SettingsApp {
             )
             .push(
                 Text::new(
+                    #[cfg(target_os = "macos")]
+                    "'+'-separated: Ctrl (⌃), Shift (⇧), Alt (⌥), Meta (⌘) — e.g. Ctrl+Shift. \
+                     Applied with digit keys 1–9. Leave empty to disable keyboard accept.",
+                    #[cfg(not(target_os = "macos"))]
                     "'+'-separated: Ctrl, Shift, Alt, Meta — e.g. Ctrl+Shift. Applied with \
                      digit keys 1–9. Leave empty to disable keyboard accept.",
                 )
@@ -1065,6 +1074,10 @@ impl SettingsApp {
         {
             chord_card = chord_card.push(
                 Text::new(
+                    #[cfg(target_os = "macos")]
+                    "At least one of Ctrl (⌃) / Alt (⌥) / Meta (⌘) is required — as written, \
+                     keyboard accept is off (clicking a suggestion still works).",
+                    #[cfg(not(target_os = "macos"))]
                     "At least one of Ctrl / Alt / Meta is required — as written, keyboard \
                      accept is off (clicking a suggestion still works).",
                 )
@@ -1270,14 +1283,15 @@ fn keycap_chip(text: String) -> Element<'static, Message> {
 
 /// A hotkey combo as a row of keycap chips: `Ctrl+Shift+Space` →
 /// [Ctrl] + [Shift] + [Space] — the same rendering the site uses for
-/// hotkey chords.
+/// hotkey chords. On macOS the chips use the platform's glyphs
+/// (⌃⇧⌘) via `display_key_token`.
 fn hotkey_chips(b: &'static theme::BrandPalette, combo: &str) -> Element<'static, Message> {
     let mut row = Row::new().spacing(4).align_y(Alignment::Center);
     for (i, part) in combo.split('+').enumerate() {
         if i > 0 {
             row = row.push(Text::new("+").size(11).color(b.muted));
         }
-        row = row.push(keycap_chip(part.to_owned()));
+        row = row.push(keycap_chip(display_key_token(part)));
     }
     row.into()
 }

--- a/crates/poltertype-core/src/settings/types.rs
+++ b/crates/poltertype-core/src/settings/types.rs
@@ -196,6 +196,15 @@ pub struct HotkeySettings {
 impl Default for HotkeySettings {
     fn default() -> Self {
         Self {
+            // macOS: Ctrl+(Shift)+Space are the OS's own input-source
+            // switching shortcuts — a global hotkey registration would
+            // preempt them and break layout switching for the user.
+            // Ctrl+Shift+P collides with nothing standard on macOS
+            // (Ctrl+P alone is the readline "previous line", but the
+            // Shift chord is free).
+            #[cfg(target_os = "macos")]
+            pause_toggle: "Ctrl+Shift+P".into(),
+            #[cfg(not(target_os = "macos"))]
             pause_toggle: "Ctrl+Shift+Space".into(),
             manual_switch_last: "Ctrl+Shift+Backspace".into(),
         }

--- a/crates/poltertype-input/src/macos.rs
+++ b/crates/poltertype-input/src/macos.rs
@@ -30,7 +30,7 @@ use core_foundation::base::TCFType;
 use core_foundation::mach_port::CFMachPortRef;
 use core_foundation::runloop::{
     CFRunLoop, CFRunLoopAddSource, CFRunLoopRunInMode, CFRunLoopSource, CFRunLoopSourceRef,
-    kCFRunLoopCommonModes,
+    kCFRunLoopCommonModes, kCFRunLoopDefaultMode,
 };
 use core_graphics::event::{
     CGEvent, CGEventFlags, CGEventTapLocation, CGEventTapOptions, CGEventTapPlacement, CGEventType,
@@ -91,6 +91,8 @@ fn request_accessibility_prompt() {
 // ─── Listener ────────────────────────────────────────────────────────
 
 static EVENT_SINK: OnceLock<parking_lot::RwLock<Option<Sender<KeyEvent>>>> = OnceLock::new();
+
+static FIRST_EVENT_LOGGED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 fn sink_slot() -> &'static parking_lot::RwLock<Option<Sender<KeyEvent>>> {
     EVENT_SINK.get_or_init(|| parking_lot::RwLock::new(None))
@@ -176,6 +178,9 @@ fn run_tap_thread(ready_tx: Sender<Result<(), String>>) {
                 };
                 if let Some(slot) = EVENT_SINK.get() {
                     if let Some(sink) = slot.read().as_ref() {
+                        if !FIRST_EVENT_LOGGED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                            debug!("first macOS key event delivered to engine");
+                        }
                         if let Err(err) = sink.try_send(ev_out) {
                             debug!(?err, "dropping macOS key event");
                         }
@@ -231,9 +236,13 @@ fn run_tap_thread(ready_tx: Sender<Result<(), String>>) {
     let _ = ready_tx.send(Ok(()));
 
     loop {
-        // Safety: standard CFRunLoop call.
+        // Safety: standard CFRunLoop call. Must run the loop in a real
+        // mode (kCFRunLoopDefaultMode is in the common-mode set the
+        // tap source was added to) — passing kCFRunLoopCommonModes as
+        // the *run* mode is legal per the docs but on macOS 15 the tap
+        // source never fires that way, so the callback starves.
         unsafe {
-            let _ = CFRunLoopRunInMode(kCFRunLoopCommonModes, 60.0, 0);
+            let _ = CFRunLoopRunInMode(kCFRunLoopDefaultMode, 60.0, 0);
         }
         if EVENT_SINK.get().map(|s| s.read().is_none()).unwrap_or(true) {
             break;

--- a/crates/poltertype-input/src/macos.rs
+++ b/crates/poltertype-input/src/macos.rs
@@ -15,9 +15,9 @@
 //! `CGEventPost` with `CGEventKeyboardSetUnicodeString` — same
 //! layout-independent contract as Windows' `KEYEVENTF_UNICODE`.
 //!
-//! > **Status:** written from Apple's documented behaviour and
-//! > validated only via `cargo check` on macOS CI. Runtime tuning
-//! > will land as macOS contributors report issues.
+//! > **Status:** validated end-to-end on macOS 15 (Intel): the tap
+//! > receives events, corrections emit, and injected events are
+//! > recognised via the user-data tag.
 
 #![allow(unused_imports, dead_code)] // macOS-only.
 
@@ -38,7 +38,7 @@ use core_graphics::event::{
 };
 use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 use crossbeam_channel::Sender;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::{InputError, InputListener, KeyDirection, KeyEmitter, KeyEvent, Modifiers};
 
@@ -195,7 +195,7 @@ fn run_tap_thread(ready_tx: Sender<Result<(), String>>) {
                         if !FIRST_EVENT_LOGGED.swap(true, std::sync::atomic::Ordering::Relaxed) {
                             debug!("first macOS key event delivered to engine");
                         }
-                        debug!(
+                        trace!(
                             scancode = ev_out.scancode,
                             ?direction,
                             shift = ev_out.modifiers.shift,

--- a/crates/poltertype-input/src/macos.rs
+++ b/crates/poltertype-input/src/macos.rs
@@ -195,6 +195,16 @@ fn run_tap_thread(ready_tx: Sender<Result<(), String>>) {
                         if !FIRST_EVENT_LOGGED.swap(true, std::sync::atomic::Ordering::Relaxed) {
                             debug!("first macOS key event delivered to engine");
                         }
+                        debug!(
+                            scancode = ev_out.scancode,
+                            ?direction,
+                            shift = ev_out.modifiers.shift,
+                            ctrl = ev_out.modifiers.control,
+                            alt = ev_out.modifiers.alt,
+                            meta = ev_out.modifiers.meta,
+                            injected = ev_out.injected,
+                            "mac key"
+                        );
                         if let Err(err) = sink.try_send(ev_out) {
                             debug!(?err, "dropping macOS key event");
                         }

--- a/crates/poltertype-input/src/macos.rs
+++ b/crates/poltertype-input/src/macos.rs
@@ -52,6 +52,14 @@ use crate::{InputError, InputListener, KeyDirection, KeyEmitter, KeyEvent, Modif
 const K_CG_KEYBOARD_EVENT_KEYCODE: u32 = 9;
 const K_CG_EVENT_SOURCE_USER_DATA: u32 = 42;
 
+/// Magic value stamped into `kCGEventSourceUserData` on every event
+/// WE post, so the listener can tag them `injected` and the engine
+/// never mistakes our own backspaces / retypes for user keystrokes.
+/// Without this the emitted events echo back through the tap as
+/// "real" input: the backspace burst poisons the word buffer right
+/// after a correction, and every second word gets skipped as tainted.
+const EMITTER_TAG: i64 = 0x504F4C54; // "POLT"
+
 // ─── Accessibility permission prompt ─────────────────────────────────
 //
 // `CGEventTapCreate` fails *silently* when the app lacks Accessibility
@@ -298,9 +306,11 @@ impl KeyEmitter for MacosEmitter {
         for _ in 0..n {
             let down = CGEvent::new_keyboard_event(src.clone(), KVK_DELETE, true)
                 .map_err(|()| InputError::Os("CGEvent::new_keyboard_event(down) failed".into()))?;
+            down.set_integer_value_field(K_CG_EVENT_SOURCE_USER_DATA, EMITTER_TAG);
             down.post(CGEventTapLocation::HID);
             let up = CGEvent::new_keyboard_event(src.clone(), KVK_DELETE, false)
                 .map_err(|()| InputError::Os("CGEvent::new_keyboard_event(up) failed".into()))?;
+            up.set_integer_value_field(K_CG_EVENT_SOURCE_USER_DATA, EMITTER_TAG);
             up.post(CGEventTapLocation::HID);
         }
         Ok(())
@@ -318,11 +328,13 @@ impl KeyEmitter for MacosEmitter {
             let down = CGEvent::new_keyboard_event(src.clone(), 0, true)
                 .map_err(|()| InputError::Os("CGEvent::new_keyboard_event failed".into()))?;
             down.set_string_from_utf16_unchecked(&utf16);
+            down.set_integer_value_field(K_CG_EVENT_SOURCE_USER_DATA, EMITTER_TAG);
             down.post(CGEventTapLocation::HID);
 
             let up = CGEvent::new_keyboard_event(src.clone(), 0, false)
                 .map_err(|()| InputError::Os("CGEvent::new_keyboard_event failed".into()))?;
             up.set_string_from_utf16_unchecked(&utf16);
+            up.set_integer_value_field(K_CG_EVENT_SOURCE_USER_DATA, EMITTER_TAG);
             up.post(CGEventTapLocation::HID);
         }
         Ok(())

--- a/crates/poltertype-input/src/macos.rs
+++ b/crates/poltertype-input/src/macos.rs
@@ -52,6 +52,42 @@ use crate::{InputError, InputListener, KeyDirection, KeyEmitter, KeyEvent, Modif
 const K_CG_KEYBOARD_EVENT_KEYCODE: u32 = 9;
 const K_CG_EVENT_SOURCE_USER_DATA: u32 = 42;
 
+// ─── Accessibility permission prompt ─────────────────────────────────
+//
+// `CGEventTapCreate` fails *silently* when the app lacks Accessibility
+// rights — no system dialog. The supported way to ask is
+// `AXIsProcessTrustedWithOptions({ kAXTrustedCheckOptionPrompt: true })`,
+// which drops the app into System Settings → Privacy & Security →
+// Accessibility and shows the "PolterType would like to control this
+// computer" alert. We call it when the tap fails to attach so a
+// first-launch user gets the prompt instead of a dead tray icon.
+
+use core_foundation::dictionary::CFDictionaryRef;
+use core_foundation::string::CFStringRef;
+
+#[link(name = "ApplicationServices", kind = "framework")]
+unsafe extern "C" {
+    fn AXIsProcessTrustedWithOptions(options: CFDictionaryRef) -> bool;
+    static kAXTrustedCheckOptionPrompt: CFStringRef;
+}
+
+/// Check Accessibility trust; prompt the user when not yet trusted.
+fn request_accessibility_prompt() {
+    use core_foundation::base::TCFType;
+    unsafe {
+        let key = core_foundation::string::CFString::wrap_under_get_rule(
+            kAXTrustedCheckOptionPrompt,
+        );
+        let value = core_foundation::boolean::CFBoolean::true_value();
+        let options = core_foundation::dictionary::CFDictionary::from_CFType_pairs(&[(
+            key.as_CFType(),
+            value.as_CFType(),
+        )]);
+        let trusted = AXIsProcessTrustedWithOptions(options.as_concrete_TypeRef());
+        debug!(trusted, "AXIsProcessTrustedWithOptions(prompt) result");
+    }
+}
+
 // ─── Listener ────────────────────────────────────────────────────────
 
 static EVENT_SINK: OnceLock<parking_lot::RwLock<Option<Sender<KeyEvent>>>> = OnceLock::new();
@@ -159,6 +195,10 @@ fn run_tap_thread(ready_tx: Sender<Result<(), String>>) {
     ) {
         Ok(t) => t,
         Err(()) => {
+            // Trigger the system Accessibility prompt so the user has
+            // a one-click path to System Settings, then report the
+            // failure as before.
+            request_accessibility_prompt();
             let _ = ready_tx.send(Err(
                 "CGEventTapCreate failed (likely missing Accessibility permission)".into(),
             ));

--- a/crates/poltertype-input/src/macos.rs
+++ b/crates/poltertype-input/src/macos.rs
@@ -162,13 +162,19 @@ fn run_tap_thread(ready_tx: Sender<Result<(), String>>) {
                 let scancode = mac_keycode_to_sc1(vk as u16);
                 let flags = event.get_flags();
                 let injected = user_data != 0;
+                // Fold Caps Lock into the shift bit the way the X11
+                // backend does: caps-on + no Shift = uppercase, caps-on
+                // + held Shift = lowercase. The engine's all-caps and
+                // replay logic rely on this combined bit.
+                let shift = flags.contains(CGEventFlags::CGEventFlagShift)
+                    ^ flags.contains(CGEventFlags::CGEventFlagAlphaShift);
 
                 let ev_out = KeyEvent {
                     vk,
                     scancode,
                     direction,
                     modifiers: Modifiers {
-                        shift: flags.contains(CGEventFlags::CGEventFlagShift),
+                        shift,
                         control: flags.contains(CGEventFlags::CGEventFlagControl),
                         alt: flags.contains(CGEventFlags::CGEventFlagAlternate),
                         meta: flags.contains(CGEventFlags::CGEventFlagCommand),
@@ -328,6 +334,15 @@ impl KeyEmitter for MacosEmitter {
 }
 
 // ─── Apple → Win SC Set-1 keycode mapping ────────────────────────────
+//
+// The engine's buffer classifier is written against Windows SC-1
+// scancodes (0x2A = LShift, 0x36 = RShift, 0x39 = Space, 0x0E =
+// Backspace, …). Apple virtual keycodes overlap that range with
+// DIFFERENT meanings — e.g. Apple 0x39 is Caps Lock but SC-1 0x39 is
+// Space, Apple 0x3C (RShift) lands in the classifier's F-row
+// "end and discard" range. Every key the classifier pattern-matches
+// must therefore be translated explicitly; an identity fallback is
+// only safe for keys outside all of the classifier's ranges.
 
 fn mac_keycode_to_sc1(kvk: u16) -> u32 {
     match kvk {
@@ -370,22 +385,62 @@ fn mac_keycode_to_sc1(kvk: u16) -> u32 {
         0x19 => 0x0A, // 9
         0x1D => 0x0B, // 0
         // Boundaries / nav
-        0x24 => 0x1C, // Return
-        0x30 => 0x0F, // Tab
-        0x31 => 0x39, // Space
-        0x33 => 0x0E, // Delete (= Backspace)
-        0x35 => 0x01, // Esc
-        0x2B => 0x33, // Comma
-        0x2F => 0x34, // Period
-        0x2C => 0x35, // Slash
-        0x29 => 0x27, // ;
-        0x27 => 0x28, // '
-        0x21 => 0x1A, // [
-        0x1E => 0x1B, // ]
-        0x2A => 0x2B, // backslash
-        0x32 => 0x29, // backtick
-        0x18 => 0x0D, // =
-        0x1B => 0x0C, // -
+        0x24 => 0x1C,  // Return
+        0x4C => 0x1C,  // Numpad Enter
+        0x30 => 0x0F,  // Tab
+        0x31 => 0x39,  // Space
+        0x33 => 0x0E,  // Delete (= Backspace)
+        0x75 => 0x53,  // Forward Delete
+        0x35 => 0x01,  // Esc
+        0x2B => 0x33,  // Comma
+        0x2F => 0x34,  // Period
+        0x2C => 0x35,  // Slash
+        0x29 => 0x27,  // ;
+        0x27 => 0x28,  // '
+        0x21 => 0x1A,  // [
+        0x1E => 0x1B,  // ]
+        0x2A => 0x2B,  // backslash
+        0x32 => 0x29,  // backtick
+        0x18 => 0x0D,  // =
+        0x1B => 0x0C,  // -
+        // Modifiers — must map onto the SC-1 modifier slots the
+        // classifier recognises as "discard, stay inside the word".
+        // Identity passthrough here was disastrous: Apple 0x3C
+        // (RShift) / 0x3B (LControl) landed in the classifier's
+        // F-row range and KILLED any word typed with the right
+        // modifier, and Apple 0x39 (Caps Lock) aliased onto SC-1
+        // Space, splitting words in two.
+        0x38 => 0x2A, // LShift
+        0x3C => 0x36, // RShift
+        0x3B => 0x1D, // LControl
+        0x3E => 0x1D, // RControl
+        0x3A => 0x38, // LOption (Alt)
+        0x3D => 0x38, // ROption
+        0x37 => 0x5B, // LCommand (SC-1 LWin)
+        0x36 => 0x5C, // RCommand (SC-1 RWin)
+        0x39 => 0x3A, // Caps Lock
+        // Arrow cluster (SC-1 extended positions → nav, end the word).
+        0x7E => 0x48, // Up
+        0x7D => 0x50, // Down
+        0x7B => 0x4B, // Left
+        0x7C => 0x4D, // Right
+        0x73 => 0x47, // Home
+        0x77 => 0x4F, // End
+        0x74 => 0x49, // PageUp
+        0x79 => 0x51, // PageDown
+        // Function row (SC-1 F1..F12 → end the word like on Windows).
+        0x7A => 0x3B, // F1
+        0x78 => 0x3C, // F2
+        0x63 => 0x3D, // F3
+        0x76 => 0x3E, // F4
+        0x60 => 0x3F, // F5
+        0x61 => 0x40, // F6
+        0x62 => 0x41, // F7
+        0x64 => 0x42, // F8
+        0x65 => 0x43, // F9
+        0x6D => 0x44, // F10
+        0x67 => 0x57, // F11
+        0x6F => 0x58, // F12
         _ => kvk as u32,
     }
 }

--- a/crates/poltertype-input/src/macos.rs
+++ b/crates/poltertype-input/src/macos.rs
@@ -425,13 +425,16 @@ fn mac_keycode_to_sc1(kvk: u16) -> u32 {
         0x32 => 0x29,  // backtick
         0x18 => 0x0D,  // =
         0x1B => 0x0C,  // -
-        // Modifiers — must map onto the SC-1 modifier slots the
+        // Modifiers — mapped onto the SC-1 modifier slots the
         // classifier recognises as "discard, stay inside the word".
-        // Identity passthrough here was disastrous: Apple 0x3C
-        // (RShift) / 0x3B (LControl) landed in the classifier's
-        // F-row range and KILLED any word typed with the right
-        // modifier, and Apple 0x39 (Caps Lock) aliased onto SC-1
-        // Space, splitting words in two.
+        // Note: macOS delivers pure modifier presses as `FlagsChanged`
+        // events, which the tap mask doesn't subscribe to yet, so
+        // these arms are dormant until it does — they exist for
+        // correctness and parity with the Windows/Linux streams,
+        // where modifiers do arrive. Without the mapping, Apple 0x3C
+        // (RShift) / 0x3B (LControl) would land in the classifier's
+        // F-row range and KILL any word typed with them, and Apple
+        // 0x39 (Caps Lock) would alias onto SC-1 Space.
         0x38 => 0x2A, // LShift
         0x3C => 0x36, // RShift
         0x3B => 0x1D, // LControl
@@ -450,7 +453,9 @@ fn mac_keycode_to_sc1(kvk: u16) -> u32 {
         0x77 => 0x4F, // End
         0x74 => 0x49, // PageUp
         0x79 => 0x51, // PageDown
-        // Function row (SC-1 F1..F12 → end the word like on Windows).
+        // Function row (SC-1 F1..F10 land in the classifier's
+        // end-and-discard range; F11/F12 sit outside it, same as on
+        // Windows — parity, not an omission).
         0x7A => 0x3B, // F1
         0x78 => 0x3C, // F2
         0x63 => 0x3D, // F3

--- a/crates/poltertype-input/src/macos.rs
+++ b/crates/poltertype-input/src/macos.rs
@@ -83,9 +83,8 @@ unsafe extern "C" {
 fn request_accessibility_prompt() {
     use core_foundation::base::TCFType;
     unsafe {
-        let key = core_foundation::string::CFString::wrap_under_get_rule(
-            kAXTrustedCheckOptionPrompt,
-        );
+        let key =
+            core_foundation::string::CFString::wrap_under_get_rule(kAXTrustedCheckOptionPrompt);
         let value = core_foundation::boolean::CFBoolean::true_value();
         let options = core_foundation::dictionary::CFDictionary::from_CFType_pairs(&[(
             key.as_CFType(),
@@ -100,7 +99,8 @@ fn request_accessibility_prompt() {
 
 static EVENT_SINK: OnceLock<parking_lot::RwLock<Option<Sender<KeyEvent>>>> = OnceLock::new();
 
-static FIRST_EVENT_LOGGED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static FIRST_EVENT_LOGGED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 fn sink_slot() -> &'static parking_lot::RwLock<Option<Sender<KeyEvent>>> {
     EVENT_SINK.get_or_init(|| parking_lot::RwLock::new(None))
@@ -407,24 +407,24 @@ fn mac_keycode_to_sc1(kvk: u16) -> u32 {
         0x19 => 0x0A, // 9
         0x1D => 0x0B, // 0
         // Boundaries / nav
-        0x24 => 0x1C,  // Return
-        0x4C => 0x1C,  // Numpad Enter
-        0x30 => 0x0F,  // Tab
-        0x31 => 0x39,  // Space
-        0x33 => 0x0E,  // Delete (= Backspace)
-        0x75 => 0x53,  // Forward Delete
-        0x35 => 0x01,  // Esc
-        0x2B => 0x33,  // Comma
-        0x2F => 0x34,  // Period
-        0x2C => 0x35,  // Slash
-        0x29 => 0x27,  // ;
-        0x27 => 0x28,  // '
-        0x21 => 0x1A,  // [
-        0x1E => 0x1B,  // ]
-        0x2A => 0x2B,  // backslash
-        0x32 => 0x29,  // backtick
-        0x18 => 0x0D,  // =
-        0x1B => 0x0C,  // -
+        0x24 => 0x1C, // Return
+        0x4C => 0x1C, // Numpad Enter
+        0x30 => 0x0F, // Tab
+        0x31 => 0x39, // Space
+        0x33 => 0x0E, // Delete (= Backspace)
+        0x75 => 0x53, // Forward Delete
+        0x35 => 0x01, // Esc
+        0x2B => 0x33, // Comma
+        0x2F => 0x34, // Period
+        0x2C => 0x35, // Slash
+        0x29 => 0x27, // ;
+        0x27 => 0x28, // '
+        0x21 => 0x1A, // [
+        0x1E => 0x1B, // ]
+        0x2A => 0x2B, // backslash
+        0x32 => 0x29, // backtick
+        0x18 => 0x0D, // =
+        0x1B => 0x0C, // -
         // Modifiers — mapped onto the SC-1 modifier slots the
         // classifier recognises as "discard, stay inside the word".
         // Note: macOS delivers pure modifier presses as `FlagsChanged`

--- a/crates/poltertype-layout/src/macos.rs
+++ b/crates/poltertype-layout/src/macos.rs
@@ -59,7 +59,12 @@ use std::ffi::c_void;
 type DispatchQueueT = *mut c_void;
 
 unsafe extern "C" {
-    fn dispatch_get_main_queue() -> DispatchQueueT;
+    /// The main dispatch queue. Modern libdispatch headers alias
+    /// `dispatch_get_main_queue()` to this global (`DISPATCH_GLOBAL_OBJECT`),
+    /// and the function symbol itself is no longer exported by
+    /// libSystem — so we link the object directly, like the `dispatch`
+    /// crate does.
+    static _dispatch_main_q: c_void;
     fn dispatch_sync_f(
         queue: DispatchQueueT,
         context: *mut c_void,
@@ -98,7 +103,7 @@ where
     };
     unsafe {
         dispatch_sync_f(
-            dispatch_get_main_queue(),
+            &raw const _dispatch_main_q as DispatchQueueT,
             &mut ctx as *mut Ctx<T, F> as *mut c_void,
             trampoline::<T, F>,
         );

--- a/crates/poltertype-layout/src/macos.rs
+++ b/crates/poltertype-layout/src/macos.rs
@@ -42,6 +42,70 @@ unsafe extern "C" {
     static kTISPropertyInputSourceIsSelectCapable: CFStringRef;
 }
 
+// ─── Main-thread dispatch ────────────────────────────────────────────
+//
+// Since macOS 14/15 the HIToolbox Text-Services layer asserts the
+// main dispatch queue (`dispatch_assert_queue` inside
+// `TSMGetInputSourceProperty` → `isValidateInputSourceRef` →
+// `islGetInputSourceListWithAdditions`). Calling ANY TIS function
+// from a worker thread — our layout poller polls every 250 ms, the
+// engine switches on its own thread — kills the process with SIGILL
+// (EXC_BAD_INSTRUCTION). Route every TIS call through the main
+// dispatch queue; run inline when the caller already is the main
+// thread, or `dispatch_sync` would deadlock.
+
+use std::ffi::c_void;
+
+type DispatchQueueT = *mut c_void;
+
+unsafe extern "C" {
+    fn dispatch_get_main_queue() -> DispatchQueueT;
+    fn dispatch_sync_f(
+        queue: DispatchQueueT,
+        context: *mut c_void,
+        work: extern "C" fn(*mut c_void),
+    );
+    fn pthread_main_np() -> i32;
+}
+
+/// Run `f` on the main dispatch queue and return its result.
+fn run_on_main<T, F>(f: F) -> T
+where
+    T: Send,
+    F: FnOnce() -> T + Send,
+{
+    if unsafe { pthread_main_np() } == 1 {
+        return f();
+    }
+    struct Ctx<T, F> {
+        f: Option<F>,
+        out: Option<T>,
+    }
+    extern "C" fn trampoline<T, F>(p: *mut c_void)
+    where
+        F: FnOnce() -> T,
+    {
+        // Safety: `dispatch_sync_f` guarantees `p` points to the live
+        // `Ctx` on the caller's stack for the duration of this call.
+        let ctx = unsafe { &mut *(p as *mut Ctx<T, F>) };
+        if let Some(f) = ctx.f.take() {
+            ctx.out = Some(f());
+        }
+    }
+    let mut ctx = Ctx {
+        f: Some(f),
+        out: None,
+    };
+    unsafe {
+        dispatch_sync_f(
+            dispatch_get_main_queue(),
+            &mut ctx as *mut Ctx<T, F> as *mut c_void,
+            trampoline::<T, F>,
+        );
+    }
+    ctx.out.expect("main-queue closure did not run")
+}
+
 // ─── Switcher impl ───────────────────────────────────────────────────
 
 pub struct MacosLayoutSwitcher;
@@ -54,86 +118,16 @@ impl MacosLayoutSwitcher {
 
 impl LayoutSwitcher for MacosLayoutSwitcher {
     fn current(&self) -> Result<LayoutId, LayoutError> {
-        // Safety: TISCopyCurrentKeyboardInputSource always returns a
-        // retained source we must release after reading the ID.
-        unsafe {
-            let src = TISCopyCurrentKeyboardInputSource();
-            if src.is_null() {
-                return Err(LayoutError::Os(
-                    "TISCopyCurrentKeyboardInputSource returned null".into(),
-                ));
-            }
-            let id = source_id_to_layout_id(src);
-            CFRelease(src);
-            id.ok_or_else(|| LayoutError::Os("could not read TIS InputSourceID".into()))
-        }
+        run_on_main(current_impl)
     }
 
     fn list_active(&self) -> Result<Vec<LayoutId>, LayoutError> {
-        // Filter for keyboard sources that the user can select.
-        let filter = unsafe {
-            let category_key = CFString::wrap_under_get_rule(kTISPropertyInputSourceCategory);
-            let category_val = CFString::wrap_under_get_rule(kTISCategoryKeyboardInputSource);
-            let select_key = CFString::wrap_under_get_rule(kTISPropertyInputSourceIsSelectCapable);
-            // Build a dictionary `{ category = keyboard, select = true }`.
-            let true_val = core_foundation::boolean::CFBoolean::true_value();
-            CFDictionary::from_CFType_pairs(&[
-                (category_key.as_CFType(), category_val.as_CFType()),
-                (select_key.as_CFType(), true_val.as_CFType()),
-            ])
-        };
-
-        // Safety: TISCreateInputSourceList retains the array; we wrap
-        // it for proper Drop. Each source inside is a CFTypeRef we
-        // read via the property accessor (no extra retain).
-        unsafe {
-            let arr_ref = TISCreateInputSourceList(filter.as_concrete_TypeRef(), false);
-            if arr_ref.is_null() {
-                return Ok(Vec::new());
-            }
-            let arr: CFArray<CFTypeRef> = CFArray::wrap_under_create_rule(arr_ref);
-            let mut out = Vec::with_capacity(arr.len() as usize);
-            for src in arr.iter() {
-                if let Some(id) = source_id_to_layout_id(*src) {
-                    out.push(id);
-                }
-            }
-            Ok(out)
-        }
+        run_on_main(list_active_impl)
     }
 
     fn switch_to(&self, id: &LayoutId) -> Result<(), LayoutError> {
-        // Resolve LayoutId → TIS source by walking the active list and
-        // matching IDs.
-        let target_str = bcp47_to_tis_id(id.as_str()).unwrap_or_else(|| id.as_str().to_owned());
-
-        // Safety: same lifetime story as `list_active`.
-        unsafe {
-            let arr_ref = TISCreateInputSourceList(std::ptr::null(), false);
-            if arr_ref.is_null() {
-                return Err(LayoutError::Os("TISCreateInputSourceList null".into()));
-            }
-            let arr: CFArray<CFTypeRef> = CFArray::wrap_under_create_rule(arr_ref);
-
-            for src in arr.iter() {
-                let cf = TISGetInputSourceProperty(*src, kTISPropertyInputSourceID);
-                if cf.is_null() {
-                    continue;
-                }
-                let s = CFString::wrap_under_get_rule(cf as CFStringRef).to_string();
-                if s == target_str {
-                    let st = TISSelectInputSource(*src);
-                    if st != 0 {
-                        return Err(LayoutError::Os(format!(
-                            "TISSelectInputSource returned OSStatus {st}"
-                        )));
-                    }
-                    return Ok(());
-                }
-            }
-        }
-
-        Err(LayoutError::NotActive(id.clone()))
+        let id = id.clone();
+        run_on_main(move || switch_to_impl(&id))
     }
 
     fn backend_name(&self) -> &'static str {
@@ -141,14 +135,100 @@ impl LayoutSwitcher for MacosLayoutSwitcher {
     }
 }
 
-unsafe fn source_id_to_layout_id(src: TISInputSourceRef) -> Option<LayoutId> {
-    // Rust 2024: even inside an `unsafe fn`, calls to unsafe items
-    // need an explicit unsafe block.
+fn current_impl() -> Result<LayoutId, LayoutError> {
+    // Safety: TISCopyCurrentKeyboardInputSource always returns a
+    // retained source we must release after reading the ID.
+    unsafe {
+        let src = TISCopyCurrentKeyboardInputSource();
+        if src.is_null() {
+            return Err(LayoutError::Os(
+                "TISCopyCurrentKeyboardInputSource returned null".into(),
+            ));
+        }
+        let id = source_id_to_layout_id(src);
+        CFRelease(src);
+        id.ok_or_else(|| LayoutError::Os("could not read TIS InputSourceID".into()))
+    }
+}
+
+fn list_active_impl() -> Result<Vec<LayoutId>, LayoutError> {
+    // Filter for keyboard sources that the user can select.
+    let filter = unsafe {
+        let category_key = CFString::wrap_under_get_rule(kTISPropertyInputSourceCategory);
+        let category_val = CFString::wrap_under_get_rule(kTISCategoryKeyboardInputSource);
+        let select_key = CFString::wrap_under_get_rule(kTISPropertyInputSourceIsSelectCapable);
+        // Build a dictionary `{ category = keyboard, select = true }`.
+        let true_val = core_foundation::boolean::CFBoolean::true_value();
+        CFDictionary::from_CFType_pairs(&[
+            (category_key.as_CFType(), category_val.as_CFType()),
+            (select_key.as_CFType(), true_val.as_CFType()),
+        ])
+    };
+
+    // Safety: TISCreateInputSourceList retains the array; we wrap
+    // it for proper Drop. Each source inside is a CFTypeRef we
+    // read via the property accessor (no extra retain).
+    unsafe {
+        let arr_ref = TISCreateInputSourceList(filter.as_concrete_TypeRef(), false);
+        if arr_ref.is_null() {
+            return Ok(Vec::new());
+        }
+        let arr: CFArray<CFTypeRef> = CFArray::wrap_under_create_rule(arr_ref);
+        let mut out = Vec::with_capacity(arr.len() as usize);
+        for src in arr.iter() {
+            if let Some(id) = source_id_to_layout_id(*src) {
+                out.push(id);
+            }
+        }
+        Ok(out)
+    }
+}
+
+fn switch_to_impl(id: &LayoutId) -> Result<(), LayoutError> {
+    // Resolve LayoutId → TIS source by walking the active list and
+    // matching IDs. A source matches when its raw TIS ID equals the
+    // reverse-mapped target *or* its forward-mapped BCP-47 equals the
+    // requested id — so `ru-RU` finds `com.apple.keylayout.RussianWin`
+    // on machines that only have the PC variant installed.
+    let target_str = bcp47_to_tis_id(id.as_str()).unwrap_or_else(|| id.as_str().to_owned());
+
+    // Safety: same lifetime story as `list_active_impl`.
+    unsafe {
+        let arr_ref = TISCreateInputSourceList(std::ptr::null(), false);
+        if arr_ref.is_null() {
+            return Err(LayoutError::Os("TISCreateInputSourceList null".into()));
+        }
+        let arr: CFArray<CFTypeRef> = CFArray::wrap_under_create_rule(arr_ref);
+
+        for src in arr.iter() {
+            let Some(raw) = source_id_string(*src) else {
+                continue;
+            };
+            if raw == target_str || tis_id_to_bcp47(&raw).as_deref() == Some(id.as_str()) {
+                let st = TISSelectInputSource(*src);
+                if st != 0 {
+                    return Err(LayoutError::Os(format!(
+                        "TISSelectInputSource returned OSStatus {st}"
+                    )));
+                }
+                return Ok(());
+            }
+        }
+    }
+
+    Err(LayoutError::NotActive(id.clone()))
+}
+
+unsafe fn source_id_string(src: TISInputSourceRef) -> Option<String> {
     let cf = unsafe { TISGetInputSourceProperty(src, kTISPropertyInputSourceID) };
     if cf.is_null() {
         return None;
     }
-    let s = unsafe { CFString::wrap_under_get_rule(cf as CFStringRef) }.to_string();
+    Some(unsafe { CFString::wrap_under_get_rule(cf as CFStringRef) }.to_string())
+}
+
+unsafe fn source_id_to_layout_id(src: TISInputSourceRef) -> Option<LayoutId> {
+    let s = unsafe { source_id_string(src) }?;
     Some(LayoutId::new(tis_id_to_bcp47(&s).unwrap_or(s)))
 }
 
@@ -161,12 +241,15 @@ fn tis_id_to_bcp47(id: &str) -> Option<String> {
     Some(
         match id {
             "com.apple.keylayout.US" => "en-US",
+            "com.apple.keylayout.ABC" => "en-US",
             "com.apple.keylayout.USInternational-PC" => "en-US",
             "com.apple.keylayout.British" => "en-GB",
             "com.apple.keylayout.Ukrainian" => "uk-UA",
             "com.apple.keylayout.Ukrainian-PC" => "uk-UA",
+            "com.apple.keylayout.UkrainianWin" => "uk-UA",
             "com.apple.keylayout.Russian" => "ru-RU",
             "com.apple.keylayout.Russian-Phonetic" => "ru-RU",
+            "com.apple.keylayout.RussianWin" => "ru-RU",
             "com.apple.keylayout.German" => "de-DE",
             "com.apple.keylayout.French" => "fr-FR",
             "com.apple.keylayout.Spanish" => "es-ES",

--- a/crates/poltertype-layout/src/macos.rs
+++ b/crates/poltertype-layout/src/macos.rs
@@ -7,8 +7,9 @@
 //! `"com.apple.keylayout.Ukrainian"`, …) which we map to BCP-47 with
 //! a small table.
 //!
-//! > **Status:** written from Apple's documented behaviour and
-//! > tested only via `cargo check` on macOS CI.
+//! > **Status:** validated on macOS 15 (Intel). Note the threading
+//! > requirement: every TIS call must run on the main dispatch queue
+//! > (HIToolbox asserts it since macOS 14/15) — see `run_on_main`.
 
 #![allow(unused_imports, dead_code)] // macOS-only; see DECISIONS for status.
 

--- a/crates/poltertype-layout/src/macos.rs
+++ b/crates/poltertype-layout/src/macos.rs
@@ -74,6 +74,12 @@ unsafe extern "C" {
 }
 
 /// Run `f` on the main dispatch queue and return its result.
+///
+/// Ordering note: callers on worker threads (the layout poller, the
+/// engine) can arrive *before* the tao event loop starts draining the
+/// main queue. They simply block in `dispatch_sync_f` until the run
+/// loop starts — never a deadlock, because the main thread itself
+/// takes the inline path and never waits on a worker.
 fn run_on_main<T, F>(f: F) -> T
 where
     T: Send,
@@ -108,7 +114,13 @@ where
             trampoline::<T, F>,
         );
     }
-    ctx.out.expect("main-queue closure did not run")
+    match ctx.out {
+        Some(v) => v,
+        // dispatch_sync_f returns only after the closure ran, so the
+        // slot is always filled; this branch is here because the
+        // compiler can't see through the FFI boundary.
+        None => unreachable!("dispatch_sync_f returned without running the closure"),
+    }
 }
 
 // ─── Switcher impl ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Runtime-tuned the macOS backend on real hardware (macOS 15.7, Intel Mac Pro). The released build crashed on launch when started from Finder and never processed a single keystroke; with these fixes the app launches, receives keys, detects wrong-layout words and corrects them end-to-end. Rebased onto current `main` (v0.6.1) — no conflicts, no version-bump metadata in this PR.

## Fixes

1. **GUI-launch crash** — `single-instance` treats the id as a flock file *path* on macOS; a bare id landed in the process cwd, which is `/` (read-only system volume) under Finder/launchd, so startup aborted with "Read-only file system". The lock now lives in the per-user config dir.

2. **SIGILL seconds after launch** — HIToolbox asserts the main dispatch queue inside `TSMGetInputSourceProperty` on modern macOS; calling any TIS function from the layout-poller / engine threads crashed the process (`EXC_BAD_INSTRUCTION`). All TIS calls are now routed through the main dispatch queue (inline when already on the main thread, `dispatch_sync_f` on `_dispatch_main_q` otherwise — `dispatch_get_main_queue` is no longer an exported symbol).

3. **Event tap delivered nothing** — the tap thread ran its CFRunLoop in `kCFRunLoopCommonModes` as the *run* mode; the tap source never fired. Now runs in `kCFRunLoopDefaultMode` (a member of the common-mode set the source is registered with).

4. **Every second word skipped as "tainted"** — the emitter posted backspaces/retyped text untagged, so they echoed back through the event tap as real user input; the settle drain saw our own backspace burst, declared the correction suspicious and poisoned the word buffer. All posted events are now stamped via `kCGEventSourceUserData`, which the listener already uses to tag `injected`.

5. **Shift / Caps Lock state was invisible to the engine** — `CGEventFlagAlphaShift` is now folded into the shift bit (parity with the X11/Wayland backends), and the Apple→SC-1 keycode table gained full modifier / navigation / F-row mappings (see the `FlagsChanged` discussion in the comments — the modifier arms are dormant scaffolding until the mask subscribes to it; the nav cluster is live today and stops corrections misfiring after caret moves).

6. **ru-RU not detected** — `com.apple.keylayout.RussianWin`/`UkrainianWin`/`ABC` were unmapped, and `switch_to` couldn't find a source when only the PC/Win variant was installed. Mappings added; `switch_to` now also matches a source by its forward-mapped BCP-47 id.

7. **Dock icon lingered while running** — tao applies `ActivationPolicy::Regular` by default, overriding `LSUIElement`; the tray app now runs as Accessory.

## Additions

- **Accessibility prompt** — when the event tap fails to attach, the app calls `AXIsProcessTrustedWithOptions(prompt: true)` instead of failing silently. (Input Monitoring is also required for key delivery; macOS prompts for it on tap creation.)
- **Autostart honoured on macOS** — the "Start automatically when I sign in" checkbox previously only edited `config.toml` on every platform; it now manages a per-user LaunchAgent, applied at startup and after every Settings-UI save. Windows/Linux keep the previous no-op contract.
- **Settings UI speaks macOS** — hotkey keycap chips render ⌃⌥⇧⌘ and key glyphs, hints name the modifiers the way the keyboard does, and the pause-hotkey default no longer collides with macOS's own input-source switching shortcut (`Ctrl+Shift+P` on macOS; existing configs untouched).

## Notes / out of scope

- The "skip word after editing" behaviour observed during testing (buffer taint after backspace-overrun / arrow navigation / Ctrl+Space) is the engine's intended conservative screen-tracking, identical on Windows/Linux — not touched here.
- Focus tracker and spelling-suggestion popup remain `noop` on macOS; clicks aren't reported by the listener — parity with the Windows backend.
- Version bump / changelog / docs sweep (`CLAUDE.md`, `PERMISSIONS.md`, `PLAN.md`, `DECISIONS.md`, landing page) intentionally left out per maintainer review — changelog prose for the release entry is in the comment thread.

## Test plan

- [x] macOS 15.7 (Intel): launches from Finder, tap attaches after Accessibility + Input Monitoring grants, wrong-layout words corrected both directions (ru↔en), shifted words, back-to-back corrections, autostart across reboot
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean
- [x] `cargo test --workspace --locked` — 245 passed