### PR TITLE
Add Spanish quick-start README

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,34 @@
+# PolterType
+
+Cambiador automático de distribución de teclado multiplataforma. Vive en la
+bandeja del sistema, detecta cuando empiezas a escribir en la distribución
+incorrecta, cambia de distribución y vuelve a escribir la última palabra, como
+un poltergeist amable que habita tu teclado.
+
+Para la documentación completa, las notas de desarrollo y las advertencias
+detalladas, consulta el [README en inglés](README.md).
+
+## Instalación
+
+Los binarios se publican en la [página de Releases](../../releases). Cada
+release incluye cuatro instaladores:
+
+| Sistema | Archivo | Cómo instalar |
+| --- | --- | --- |
+| Windows 10 / 11 | `poltertype-<ver>-x86_64-pc-windows-msvc.msi` | Doble clic. Instalación por usuario, sin derechos de administrador ni UAC. SmartScreen puede mostrar "Windows protegió tu PC" → **Más información** → **Ejecutar de todas formas**. |
+| macOS 11+ (Intel y Apple Silicon) | `poltertype-<ver>-universal-apple-darwin.dmg` | Abre el DMG y arrastra `poltertype.app` a `/Applications`. En el primer lanzamiento, haz clic derecho sobre la app → **Abrir** (o ejecuta `xattr -dr com.apple.quarantine /Applications/poltertype.app`). Luego concede **Accesibilidad** y **Monitoreo de entrada** cuando macOS lo solicite. |
+| Linux (x86_64) | `poltertype-<ver>-x86_64.AppImage` | `chmod +x` y ejecuta. Instalación por usuario, sin instalación del sistema. Consulta [docs/PERMISSIONS.md](docs/PERMISSIONS.md) para el acceso `evdev` en Wayland. |
+| Linux (aarch64) | `poltertype-<ver>-aarch64.AppImage` | Igual que arriba, para ARM64: Raspberry Pi 5, Asahi, laptops y servidores ARM. |
+
+> Los instaladores todavía **no están firmados**, por eso Gatekeeper o
+> SmartScreen advierten en el primer lanzamiento. La firma de código llegará en
+> una fase posterior.
+
+> **No hay Flatpak y no lo habrá.** PolterType escribe en `/dev/uinput`, lo que
+> ningún permiso de Flatpak concede salvo `--device=all` (todo el árbol de
+> dispositivos), y no existe un portal para ello. El cambio de distribución
+> también necesita binarios del sistema (`hyprctl`, `gsettings`, `qdbus`,
+> `ibus`) que una sandbox no tiene. Usa el AppImage o un paquete nativo.
+
+La compilación desde el código fuente se documenta en
+[CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Lives in the system tray. Detects when you start typing in the wrong
 layout, switches it, and retypes the last word — like a friendly
 poltergeist that haunts your keyboard.
 
+> 🌐 [Español](README.es.md)
+
 ![Typing "ma;ana" with the wrong layout active: PolterType switches the layout and retypes it as "mañana", and the rest of the sentence comes out right as typed](docs/screenshots/demo.gif)
 
 *Live capture, unedited timing: `ñ` sits on the US `;` key, so Spanish


### PR DESCRIPTION
Adds a short `README.es.md` covering the stable quick-start content, the install table, platform-specific permission notes, and the honest caveats from the English README. Adds the Spanish language link at the top of the main README.

Closes #16