### PR TITLE
win: read keyboard mappings from the OS instead of assuming a variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to PolterType are recorded here. The format is
 loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project follows [Semantic Versioning](https://semver.org/).
 
+## [0.14.3] — the keyboard you actually have
+
+### Fixed — a language is not a keyboard
+
+- **Windows keyboard mappings are now read from the OS instead of
+  assumed.** Windows identifies a layout by its *language*, so every
+  Bulgarian keyboard arrives as `bg-BG` — and Windows ships three that
+  are genuinely different. PolterType bundled one mapping per language
+  and handed it to whoever asked, which meant a user on Bulgarian
+  (Phonetic) got a table wrong on **45 of its 48 keys**. Nothing
+  errored and nothing appeared in the interface: corrections were
+  simply built from a keyboard they do not own, and the detector was
+  reasoning about a word they never typed.
+  PolterType now asks Windows what each installed keyboard actually
+  produces and uses that in place of the bundled table. This fixes
+  every variant at once — including the ones we never bundled, and
+  custom layouts we have never heard of — rather than the handful
+  somebody remembered to describe. Turkish Q vs F and Ukrainian
+  standard vs Enhanced carried the same risk and are covered by the
+  same change.
+
+- **Ukrainian `ґ` is on the right key on Windows.** The bundled
+  mapping puts it where xkb does; Windows puts it on the extra key
+  next to the left Shift and gives the old position to `\`. One TOML
+  cannot be right for both, so Windows users had one key wrong in a
+  layout that was otherwise exact. They now get the Windows answer
+  while Linux keeps the xkb one, with no change to the data. The
+  Ukrainian apostrophe and the hryvnia sign — absent from the bundled
+  table entirely — came along with it.
+
+- **Accepting a suggestion picks the same key every time.** Where a
+  layout carries one character on two keys, the reverse lookup
+  iterated a hash map and could pick either, run to run. It now takes
+  the lower scancode, which is also the key that exists on keyboards
+  that don't have the extra ISO one.
+
+Nothing changes for Linux or macOS: the bundled TOMLs are untouched
+and a backend that cannot describe its keyboards simply keeps using
+them. A layout TOML in `<config-dir>/poltertype/layouts/` still
+outranks everything, including the OS.
+
 ## [0.14.2] — it stops going quiet on you
 
 ### Fixed — teaching PolterType a word, three ways it didn't stick

--- a/crates/poltertype-app/src/main.rs
+++ b/crates/poltertype-app/src/main.rs
@@ -228,6 +228,31 @@ fn main() -> Result<()> {
         }
     };
 
+    // `list_active` names languages, which is all the OS layout APIs
+    // agree on — but a language is not a keyboard. Bulgarian alone has
+    // three genuinely different ones under `bg-BG`, and a bundled
+    // mapping can only describe one. Ask the backend what the
+    // installed keyboards actually produce and let the DB correct
+    // itself; a backend that can't answer returns nothing and the
+    // bundled tables stand.
+    let os_keymaps = match layout_switcher.describe_keymaps() {
+        Ok(maps) => {
+            info!(
+                count = maps.len(),
+                described = ?maps.iter().map(|m| (&m.id, &m.variant)).collect::<Vec<_>>(),
+                "OS keyboard descriptions"
+            );
+            maps
+        }
+        Err(e) => {
+            warn!(
+                ?e,
+                "could not describe OS keyboards; using bundled mappings as-is"
+            );
+            Vec::new()
+        }
+    };
+
     let user_wordlist_dir = poltertype_core::layouts::user_wordlist_dir();
     let user_layout_dir = poltertype_core::layouts::user_layout_dir();
     let layouts = Arc::new(
@@ -236,6 +261,7 @@ fn main() -> Result<()> {
             active_filter: active_os_layouts.as_deref(),
             user_layout_dir: user_layout_dir.as_deref(),
             user_wordlist_dir: user_wordlist_dir.as_deref(),
+            os_keymaps: Some(&os_keymaps),
         })
         .context("load layout DB")?,
     );

--- a/crates/poltertype-core/src/layouts/consts.rs
+++ b/crates/poltertype-core/src/layouts/consts.rs
@@ -15,3 +15,14 @@ pub const BUNDLED_LAYOUT_STEMS: &[&str] = &[
     "en_us", "uk_ua", "ru_ru", "de_de", "es_es", "fr_fr", "pl_pl", "cs_cz", "el_gr", "he_il",
     "tr_tr", "bg_bg", "it_it", "pt_pt", "pt_br",
 ];
+
+/// Fewest keys an [`poltertype_types::OsKeymap`] must carry before we
+/// let it replace a bundled mapping.
+///
+/// A whole character block is 47–48 keys and every real keyboard fills
+/// nearly all of it, so this is not a judgement about unusual layouts
+/// — it is a floor under a query that went wrong. Anything sparser
+/// means the OS answered badly, and a bundled mapping that is right
+/// for the wrong variant still beats one that is missing half its
+/// alphabet.
+pub const MIN_OS_KEYMAP_KEYS: usize = 30;

--- a/crates/poltertype-core/src/layouts/db.rs
+++ b/crates/poltertype-core/src/layouts/db.rs
@@ -10,6 +10,7 @@ use super::consts::BUNDLED_LAYOUT_STEMS;
 use super::enums::LayoutLoadError;
 use super::files::*;
 use super::helpers::{compute_letter_scancodes, peek_layout_id};
+use super::os_keymap::apply_os_keymaps;
 use super::plugins::load_plugin_packs;
 use super::types::{LayoutMapping, LoadOptions};
 
@@ -105,6 +106,16 @@ impl LayoutDb {
         // i.e. a user can still override a plug-in by dropping a TOML
         // with the same id under `<config-dir>/poltertype/layouts/`.
         load_plugin_packs(data_dir, opts.user_wordlist_dir, &mut by_id);
+
+        // ── What the OS says these keyboards really do ────────────
+        //
+        // Applied over everything we shipped and under the user's own
+        // TOMLs. A bundled mapping describes *a* keyboard for the
+        // language; this describes *the* keyboard on this machine.
+        // See `os_keymap` for why that distinction has teeth.
+        if let Some(keymaps) = opts.os_keymaps {
+            apply_os_keymaps(keymaps, &mut by_id);
+        }
 
         // ── User-side TOMLs (always loaded, never filtered) ───────
         if let Some(dir) = opts.user_layout_dir {

--- a/crates/poltertype-core/src/layouts/mod.rs
+++ b/crates/poltertype-core/src/layouts/mod.rs
@@ -25,6 +25,15 @@
 //! loading ~7-15 MB of fr-FR / es-ES / de-DE FST data they'd never
 //! query.
 //!
+//! ## OS keymaps
+//!
+//! [`LoadOptions::os_keymaps`] carries what the platform backend says
+//! the user's keyboards actually produce. Where a language has more
+//! than one keyboard — Windows ships three Bulgarian ones under the
+//! single id `bg-BG` — a bundled table can only be right for one of
+//! them, so the OS's answer replaces it. See [`os_keymap`] for the
+//! precedence chain and what it deliberately does not fix.
+//!
 //! ## User extensions
 //!
 //! Two override paths layered on top of the bundled set:
@@ -40,6 +49,7 @@ mod db;
 mod enums;
 mod files;
 mod helpers;
+mod os_keymap;
 mod plugins;
 mod types;
 

--- a/crates/poltertype-core/src/layouts/os_keymap.rs
+++ b/crates/poltertype-core/src/layouts/os_keymap.rs
@@ -1,0 +1,121 @@
+//! Correcting bundled mappings against the keyboards the OS reports.
+//!
+//! A [`LayoutId`] names a *language*, because that is all the OS
+//! layout APIs agree on — but a language is not a keyboard. Windows
+//! ships three genuinely different Bulgarian keyboards under the one
+//! id `bg-BG`, and `bg_bg.toml` can only describe one of them: for a
+//! user on Bulgarian (Phonetic) it is wrong at 79 of 94 key
+//! positions. Nothing errors. The corrections are simply built from a
+//! keyboard they do not have.
+//!
+//! So we ask. `LayoutSwitcher::describe_keymaps` reports what the
+//! installed keyboards actually produce, and this module lays that
+//! over the bundled tables. The mapping keeps its identity — id, name,
+//! script, vowels, dictionary are all per-*language* and stay — and
+//! only the key table, which is per-*keyboard*, is replaced.
+//!
+//! Where this sits in the precedence chain matters:
+//!
+//! ```text
+//! bundled  ←  plug-in packs  ←  OS keymaps  ←  user TOMLs
+//! ```
+//!
+//! The OS outranks anything we shipped, because it is describing the
+//! machine rather than guessing at it. A user TOML still outranks the
+//! OS: it is an explicit "I know what my keyboard does", and it is the
+//! escape hatch if this ever reads a keyboard wrong.
+
+use std::collections::{HashMap, HashSet};
+
+use poltertype_types::{LayoutId, OsKeymap};
+use tracing::{debug, info, warn};
+
+use super::consts::MIN_OS_KEYMAP_KEYS;
+use super::types::LayoutMapping;
+
+/// Replace the key table of every loaded layout the OS could describe.
+///
+/// Languages we ship no mapping for are skipped: a key table without a
+/// dictionary detects nothing, so synthesising a layout from the OS
+/// alone would be a different feature rather than a fix.
+pub(super) fn apply_os_keymaps(keymaps: &[OsKeymap], by_id: &mut HashMap<LayoutId, LayoutMapping>) {
+    let mut claimed: HashSet<&LayoutId> = HashSet::new();
+
+    for km in keymaps {
+        let Some(mapping) = by_id.get_mut(&km.id) else {
+            continue;
+        };
+
+        if km.keys.len() < MIN_OS_KEYMAP_KEYS {
+            warn!(
+                layout = %km.id,
+                variant = %km.variant,
+                keys = km.keys.len(),
+                "OS described too few keys to be a whole keyboard; keeping the bundled mapping"
+            );
+            continue;
+        }
+
+        // Two keyboards for one language collapse to one id and we can
+        // only hold one table. The backend puts the keyboard currently
+        // in effect first, so the first is the one to keep.
+        if !claimed.insert(&km.id) {
+            warn!(
+                layout = %km.id,
+                variant = %km.variant,
+                "another keyboard is already installed for this language; ignoring this one"
+            );
+            continue;
+        }
+
+        let derived: HashMap<u32, (char, Option<char>)> = km
+            .keys
+            .iter()
+            .map(|&(scancode, plain, shift)| (scancode, (plain, shift)))
+            .collect();
+
+        // Worth counting rather than just swapping: a large number
+        // here is the signature of the variant problem, and it is the
+        // one line in the log that says which keyboard the user has.
+        let replaced = derived
+            .iter()
+            .filter(|(scancode, produced)| mapping.keys.get(*scancode) != Some(*produced))
+            .count();
+        let dropped = mapping
+            .keys
+            .keys()
+            .filter(|scancode| !derived.contains_key(*scancode))
+            .count();
+
+        info!(
+            layout = %km.id,
+            variant = %km.variant,
+            keys = derived.len(),
+            replaced,
+            dropped,
+            "adopted the OS keymap for this keyboard"
+        );
+
+        // Which keys, not just how many. "My `ґ` stopped working" is
+        // the shape a report of this taking a wrong turn will have,
+        // and this is the line that answers it in one read. Layout
+        // tables are not typed text — nothing here is user input.
+        if replaced > 0 || dropped > 0 {
+            let mut changes: Vec<String> = derived
+                .iter()
+                .filter(|(scancode, produced)| mapping.keys.get(*scancode) != Some(*produced))
+                .map(|(scancode, (plain, shift))| {
+                    let was = match mapping.keys.get(scancode) {
+                        Some((p, s)) => format!("{p}{}", s.map(String::from).unwrap_or_default()),
+                        None => "—".to_owned(),
+                    };
+                    format!("0x{scancode:02X} {was}→{plain}{}", shift.unwrap_or(' '))
+                })
+                .collect();
+            changes.sort_unstable();
+            debug!(layout = %km.id, changes = %changes.join(", "), "keys the OS disagreed on");
+        }
+
+        mapping.keys = derived;
+    }
+}

--- a/crates/poltertype-core/src/layouts/tests.rs
+++ b/crates/poltertype-core/src/layouts/tests.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use poltertype_types::{LayoutId, WordKey};
+use poltertype_types::{LayoutId, OsKeymap, WordKey};
 
 use super::consts::*;
 use super::helpers::*;
@@ -803,4 +803,176 @@ fn overlay_is_freshly_read_on_each_build() {
         !second_dict.contains(first_token),
         "old overlay must not leak into the fresh load"
     );
+}
+
+// ─── OS keymaps: a language is not a keyboard (issue #20) ─────────
+
+/// A keyboard the OS could plausibly describe: `n` keys from scancode
+/// `0x10` up, each producing a distinct character from `base` on, so a
+/// test can tell an adopted table from a bundled one at a glance.
+fn os_keymap(id: &str, variant: &str, n: u32, base: char) -> OsKeymap {
+    let keys = (0..n)
+        .map(|i| {
+            let ch = char::from_u32(base as u32 + i).expect("test alphabet stays in range");
+            (0x10 + i, ch, None)
+        })
+        .collect();
+    OsKeymap {
+        id: LayoutId::from(id),
+        variant: variant.to_owned(),
+        keys,
+    }
+}
+
+fn plain(scancode: u32) -> WordKey {
+    WordKey {
+        scancode,
+        shift: false,
+        timestamp_ms: 0,
+    }
+}
+
+/// The whole point of #20: when the OS describes the keyboard the user
+/// actually has, that description wins over the one we guessed.
+#[test]
+fn an_os_keymap_replaces_the_bundled_key_table() {
+    let want = [LayoutId::from("bg-BG")];
+    let maps = [os_keymap("bg-BG", "00040402", 40, 'а')];
+    let db = LayoutDb::load(LoadOptions {
+        active_filter: Some(&want),
+        os_keymaps: Some(&maps),
+        ..Default::default()
+    })
+    .expect("load with OS keymaps");
+
+    let bg = db.get(&LayoutId::from("bg-BG")).expect("bg-BG present");
+    assert_eq!(
+        bg.keys.len(),
+        40,
+        "the OS table describes the whole keyboard, so it replaces rather than merges"
+    );
+    assert_eq!(
+        bg.translate_key(plain(0x10)),
+        Some('а'),
+        "0x10 should come from the OS ('а'), not from bg_bg.toml (',')"
+    );
+
+    // Identity is per-*language* and has to survive: the name, the
+    // script and the dictionary all describe Bulgarian, not a
+    // particular Bulgarian keyboard.
+    assert_eq!(bg.name, "Български");
+    assert!(
+        bg.dictionary.is_some(),
+        "adopting a keymap must not cost the layout its dictionary"
+    );
+}
+
+/// A key table without a dictionary detects nothing, so a language we
+/// ship no mapping for is left alone rather than half-invented.
+#[test]
+fn an_os_keymap_for_a_language_we_do_not_ship_is_ignored() {
+    let maps = [os_keymap("kk-KZ", "0000043f", 40, 'а')];
+    let db = LayoutDb::load(LoadOptions {
+        os_keymaps: Some(&maps),
+        ..Default::default()
+    })
+    .expect("load with an unknown-language keymap");
+
+    assert!(db.get(&LayoutId::from("kk-KZ")).is_none());
+    assert_eq!(db.len(), BUNDLED_LAYOUT_STEMS.len());
+}
+
+/// The floor under a query that went wrong. A mapping that is right
+/// for the wrong variant still beats one missing half its alphabet.
+#[test]
+fn a_sparse_os_keymap_is_refused() {
+    let want = [LayoutId::from("bg-BG")];
+    let sparse = MIN_OS_KEYMAP_KEYS as u32 - 1;
+    let maps = [os_keymap("bg-BG", "00040402", sparse, 'а')];
+    let db = LayoutDb::load(LoadOptions {
+        active_filter: Some(&want),
+        os_keymaps: Some(&maps),
+        ..Default::default()
+    })
+    .expect("load with a sparse OS keymap");
+
+    let bg = db.get(&LayoutId::from("bg-BG")).expect("bg-BG present");
+    assert_eq!(
+        bg.translate_key(plain(0x10)),
+        Some(','),
+        "bg_bg.toml should still be in charge"
+    );
+}
+
+/// Two keyboards for one language collapse to one `LayoutId` and only
+/// one table can be held. The backend puts the keyboard currently in
+/// effect first; the loader keeps that one.
+#[test]
+fn only_the_first_keyboard_per_language_is_adopted() {
+    let want = [LayoutId::from("bg-BG")];
+    let maps = [
+        os_keymap("bg-BG", "00030402", 40, 'а'),
+        os_keymap("bg-BG", "00040402", 40, 'ѐ'),
+    ];
+    let db = LayoutDb::load(LoadOptions {
+        active_filter: Some(&want),
+        os_keymaps: Some(&maps),
+        ..Default::default()
+    })
+    .expect("load with two keyboards for one language");
+
+    let bg = db.get(&LayoutId::from("bg-BG")).expect("bg-BG present");
+    assert_eq!(bg.translate_key(plain(0x10)), Some('а'));
+}
+
+/// The escape hatch. If this mechanism ever reads a keyboard wrong,
+/// a user TOML is how someone takes back control — so it has to
+/// outrank the OS, not the other way round.
+#[test]
+fn a_user_toml_still_outranks_an_os_keymap() {
+    let layout_tmp = TmpDir::new("os-keymap-user-wins");
+    layout_tmp.write(
+        "en_us.toml",
+        &minimal_layout_toml("en-US", "USER-OVERRIDE-EN", "Latin"),
+    );
+
+    let want = [LayoutId::from("en-US")];
+    let maps = [os_keymap("en-US", "00000409", 40, 'а')];
+    let db = LayoutDb::load(LoadOptions {
+        active_filter: Some(&want),
+        user_layout_dir: Some(&layout_tmp.0),
+        os_keymaps: Some(&maps),
+        ..Default::default()
+    })
+    .expect("load with a user TOML and an OS keymap");
+
+    let en = db.get(&LayoutId::from("en-US")).expect("en-US present");
+    assert_eq!(en.name, "USER-OVERRIDE-EN");
+    assert_eq!(
+        en.translate_key(plain(0x10)),
+        Some('x'),
+        "the user's own table must survive the OS overlay intact"
+    );
+}
+
+/// `key_for_char` iterates a `HashMap`, and an OS-derived table really
+/// does put one character on two keys — en-US carries `\` on both
+/// `0x2B` and the extra ISO key `0x56`. Without a tie-break the
+/// suggestion-accept path would pick a different key run to run.
+#[test]
+fn key_for_char_breaks_ties_on_the_lowest_scancode() {
+    let toml = r#"
+id     = "zz-ZZ"
+name   = "Ambiguous"
+script = "Latin"
+
+[keys]
+0x2B = { plain = "\\", shift = "|" }
+0x56 = { plain = "\\", shift = "|" }
+"#;
+    let mapping = LayoutMapping::from_toml_str(toml).expect("parse");
+    for _ in 0..32 {
+        assert_eq!(mapping.key_for_char('\\'), Some((0x2B, false)));
+        assert_eq!(mapping.key_for_char('|'), Some((0x2B, true)));
+    }
 }

--- a/crates/poltertype-core/src/layouts/types.rs
+++ b/crates/poltertype-core/src/layouts/types.rs
@@ -117,17 +117,26 @@ impl LayoutMapping {
     /// in Wayland-native / terminal apps. Linear over the ~48-key
     /// table; callers do this a handful of times per accepted word.
     /// Unshifted match wins when a character appears in both columns.
+    ///
+    /// Ties break on the lowest scancode, which matters more than it
+    /// looks: a real keyboard puts the same character on two keys
+    /// often enough — en-US carries `\` on both `0x2B` and the extra
+    /// ISO key `0x56` — and iterating a `HashMap` would otherwise pick
+    /// a different one run to run. The low scancode is also the key
+    /// that exists on every board, ISO or ANSI.
     pub fn key_for_char(&self, ch: char) -> Option<(u32, bool)> {
-        let mut shifted_hit = None;
+        let mut plain_hit: Option<u32> = None;
+        let mut shifted_hit: Option<u32> = None;
         for (&sc, &(plain, shift)) in &self.keys {
             if plain == ch {
-                return Some((sc, false));
-            }
-            if shift == Some(ch) && shifted_hit.is_none() {
-                shifted_hit = Some((sc, true));
+                plain_hit = Some(plain_hit.map_or(sc, |best| best.min(sc)));
+            } else if shift == Some(ch) {
+                shifted_hit = Some(shifted_hit.map_or(sc, |best| best.min(sc)));
             }
         }
-        shifted_hit
+        plain_hit
+            .map(|sc| (sc, false))
+            .or(shifted_hit.map(|sc| (sc, true)))
     }
 
     /// Translate an entire word buffer into a string under this layout.
@@ -190,4 +199,11 @@ pub struct LoadOptions<'a> {
     pub user_layout_dir: Option<&'a Path>,
     /// `<config-dir>/poltertype/wordlists/` — user wordlist overlays.
     pub user_wordlist_dir: Option<&'a Path>,
+    /// What the OS says the user's keyboards actually produce —
+    /// typically `LayoutSwitcher::describe_keymaps()`. Each entry
+    /// replaces the key table of the layout it names, because a
+    /// [`LayoutId`] is a language and a language is not a keyboard.
+    /// `None` (or an empty slice) leaves the bundled tables alone.
+    /// See [`super::os_keymap`].
+    pub os_keymaps: Option<&'a [poltertype_types::OsKeymap]>,
 }

--- a/crates/poltertype-layout/src/traits.rs
+++ b/crates/poltertype-layout/src/traits.rs
@@ -1,7 +1,7 @@
 //! The OS layout-switcher extension point.
 
 use crate::*;
-pub use poltertype_types::LayoutId;
+pub use poltertype_types::{LayoutId, OsKeymap};
 
 pub trait LayoutSwitcher: Send + Sync {
     /// Layout currently effective for the foreground window.
@@ -15,4 +15,25 @@ pub trait LayoutSwitcher: Send + Sync {
     fn switch_to(&self, id: &LayoutId) -> Result<(), LayoutError>;
 
     fn backend_name(&self) -> &'static str;
+
+    /// Ask the OS what the user's keyboards actually produce, key by
+    /// key — one [`OsKeymap`] per installed keyboard.
+    ///
+    /// [`current`](Self::current) and [`list_active`](Self::list_active)
+    /// can only name a *language*, and a language is not a keyboard:
+    /// where a language has several keyboard variants, the bundled
+    /// mapping describes one of them and is wrong — silently, and by
+    /// most of the alphabet — for the rest. A backend that can answer
+    /// this question lets the layout DB correct itself against the
+    /// machine it is running on.
+    ///
+    /// Ordering is significant: the keyboard currently in effect comes
+    /// first, because the DB keeps the first entry per language when a
+    /// user has installed more than one keyboard for it.
+    ///
+    /// The default is an empty list — "this backend cannot tell you" —
+    /// which leaves the bundled mappings untouched.
+    fn describe_keymaps(&self) -> Result<Vec<OsKeymap>, LayoutError> {
+        Ok(Vec::new())
+    }
 }

--- a/crates/poltertype-layout/src/windows.rs
+++ b/crates/poltertype-layout/src/windows.rs
@@ -10,19 +10,60 @@
 //!
 //! HKL → BCP-47 mapping uses `LCIDToLocaleName` on the low word of
 //! the HKL, which holds the input-language LCID.
+//!
+//! * Describing: `MapVirtualKeyExW` + `ToUnicodeEx` against each
+//!   active HKL. The low word of an HKL says which *language* a
+//!   keyboard is for; only the keys themselves say which *keyboard*
+//!   it is.
 
 use std::collections::HashMap;
 use std::ffi::c_void;
 
+use poltertype_types::OsKeymap;
 use tracing::{debug, warn};
 use windows::Win32::Foundation::{LPARAM, WPARAM};
 use windows::Win32::Globalization::LCIDToLocaleName;
-use windows::Win32::UI::Input::KeyboardAndMouse::{GetKeyboardLayout, GetKeyboardLayoutList, HKL};
+use windows::Win32::UI::Input::KeyboardAndMouse::{
+    GetKeyboardLayout, GetKeyboardLayoutList, HKL, MAPVK_VSC_TO_VK_EX, MapVirtualKeyExW,
+    ToUnicodeEx, VK_SHIFT,
+};
 use windows::Win32::UI::WindowsAndMessaging::{
     GetForegroundWindow, GetWindowThreadProcessId, PostMessageW, WM_INPUTLANGCHANGEREQUEST,
 };
 
 use crate::{LayoutError, LayoutId, LayoutSwitcher};
+
+/// The character block we ask every keyboard about: number row, the
+/// three letter rows, the backtick (`0x29`) and backslash (`0x2B`)
+/// keys that move between ANSI and ISO boards, and the extra key next
+/// to the left Shift (`0x56`) that only ISO boards carry.
+///
+/// Deliberately a fixed list rather than one derived from the loaded
+/// mappings: [`LayoutSwitcher::describe_keymaps`] promises a table
+/// that is *complete*, and completeness only means something against
+/// a known set of questions. A scancode asked about and left out of
+/// the answer is evidence that the key produces nothing — which is
+/// what lets the layout DB replace a stale mapping instead of merging
+/// into it.
+const CHARACTER_SCANCODES: &[u32] = &[
+    // Number row: `1` … `=`
+    0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, //
+    // Q row: `Q` … `]`
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, //
+    // A row: `A` … `'`
+    0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, //
+    // Backtick and backslash
+    0x29, 0x2B, //
+    // Z row: `Z` … `/`
+    0x2C, 0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, //
+    // The extra ISO key
+    0x56,
+];
+
+/// `ToUnicodeEx` `wFlags` bit 2: "do not change keyboard state".
+/// Windows 10 1607 and newer honour it; older builds ignore unknown
+/// bits, which is why [`char_at`] drains dead keys by hand as well.
+const TOUNICODE_NO_STATE_CHANGE: u32 = 0x4;
 
 pub struct WindowsLayoutSwitcher;
 
@@ -90,6 +131,26 @@ impl LayoutSwitcher for WindowsLayoutSwitcher {
     fn backend_name(&self) -> &'static str {
         "windows-hkl"
     }
+
+    fn describe_keymaps(&self) -> Result<Vec<OsKeymap>, LayoutError> {
+        let mut hkls = self.raw_active()?;
+
+        // The keyboard in effect right now goes first. When a user has
+        // installed two keyboards for one language both collapse to the
+        // same `LayoutId` and the DB can only keep one of them — the one
+        // they are typing on is by far the better guess.
+        // Safety: pure Win32 calls with no aliasing concerns.
+        let current = unsafe {
+            let hwnd = GetForegroundWindow();
+            let tid = GetWindowThreadProcessId(hwnd, None);
+            GetKeyboardLayout(tid)
+        };
+        if let Some(pos) = hkls.iter().position(|h| h.0 == current.0) {
+            hkls.swap(0, pos);
+        }
+
+        Ok(hkls.into_iter().map(describe_hkl).collect())
+    }
 }
 
 impl WindowsLayoutSwitcher {
@@ -126,3 +187,85 @@ fn hkl_to_layout_id(hkl: HKL) -> LayoutId {
     }
     LayoutId::new(format!("hkl:{raw:08x}"))
 }
+
+/// Describe one keyboard: what each key of the character block
+/// produces, unshifted and shifted.
+///
+/// `variant` is the raw HKL in hex, which for a standard keyboard is
+/// exactly its KLID (`00030402` = Bulgarian Phonetic Traditional).
+/// Imported and third-party layouts get a synthesised high word
+/// instead, so it is only ever logged — never matched on.
+fn describe_hkl(hkl: HKL) -> OsKeymap {
+    let raw = hkl.0 as usize as u32;
+    let variant = format!("{raw:08x}");
+    let mut keys = Vec::with_capacity(CHARACTER_SCANCODES.len());
+
+    for &sc in CHARACTER_SCANCODES {
+        // `MAPVK_VSC_TO_VK_EX` resolves the scancode through *this*
+        // layout. Zero means the keyboard has nothing on that key.
+        // Safety: pure Win32 call against a handle the OS gave us.
+        let vk = unsafe { MapVirtualKeyExW(sc, MAPVK_VSC_TO_VK_EX, hkl) };
+        if vk == 0 {
+            continue;
+        }
+        let Some(plain) = char_at(vk, sc, hkl, false) else {
+            continue;
+        };
+        // `None` when Shift changes nothing — same convention the
+        // bundled TOMLs use for their optional `shift` field.
+        let shift = char_at(vk, sc, hkl, true).filter(|c| *c != plain);
+        keys.push((sc, plain, shift));
+    }
+
+    let id = hkl_to_layout_id(hkl);
+    debug!(%id, %variant, keys = keys.len(), "described keyboard");
+    OsKeymap { id, variant, keys }
+}
+
+/// What does this key produce under `hkl`, with or without Shift?
+///
+/// Two `ToUnicodeEx` quirks decide the shape of this function:
+///
+/// * **Dead keys return `-1`** — and still write their character.
+///   Reading that as "no character" silently loses every accented
+///   key; it was also 22 of the 35 apparent mismatches in the audit
+///   behind issue #20, which were an artefact of the audit tool
+///   rather than real differences.
+/// * **It mutates keyboard state.** A pending dead key left behind
+///   would compose itself into whatever the *user* types next. We ask
+///   Windows not to touch the state via [`TOUNICODE_NO_STATE_CHANGE`]
+///   and drain by hand anyway, since older builds ignore the flag.
+fn char_at(vk: u32, sc: u32, hkl: HKL, shift: bool) -> Option<char> {
+    let mut state = [0u8; 256];
+    if shift {
+        state[VK_SHIFT.0 as usize] = 0x80;
+    }
+
+    let mut buf = [0u16; 8];
+    // Safety: both buffers are ours and correctly sized; the call
+    // cannot outlive them.
+    let n = unsafe { ToUnicodeEx(vk, sc, &state, &mut buf, TOUNICODE_NO_STATE_CHANGE, hkl) };
+    if n < 0 {
+        // Dead key — feed it the same keystroke again so the pending
+        // composition resolves and nothing is left waiting.
+        let mut scratch = [0u16; 8];
+        // Safety: as above.
+        unsafe { ToUnicodeEx(vk, sc, &state, &mut scratch, TOUNICODE_NO_STATE_CHANGE, hkl) };
+    }
+    if n == 0 {
+        return None;
+    }
+
+    let len = if n < 0 {
+        1
+    } else {
+        (n as usize).min(buf.len())
+    };
+    String::from_utf16_lossy(&buf[..len])
+        .chars()
+        .next()
+        .filter(|c| !c.is_control())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/poltertype-layout/src/windows/tests.rs
+++ b/crates/poltertype-layout/src/windows/tests.rs
@@ -1,0 +1,166 @@
+//! Windows layout-backend tests.
+//!
+//! These talk to the real OS — they read the keyboards this machine
+//! actually has rather than a fixture. That is deliberate: the bug
+//! behind issue #20 was invisible to any test that mocked the
+//! keyboard, because the wrong answer was a perfectly well-formed
+//! mapping. It just belonged to somebody else's keyboard.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use super::*;
+
+/// How many `(plain, shift)` positions the two keyboards disagree on,
+/// counting a key present in one and absent from the other as two.
+fn positions_differing(a: &OsKeymap, b: &OsKeymap) -> usize {
+    let index = |km: &OsKeymap| -> HashMap<u32, (char, Option<char>)> {
+        km.keys.iter().map(|&(sc, p, s)| (sc, (p, s))).collect()
+    };
+    let (left, right) = (index(a), index(b));
+    let mut scancodes: Vec<u32> = left.keys().chain(right.keys()).copied().collect();
+    scancodes.sort_unstable();
+    scancodes.dedup();
+
+    scancodes
+        .into_iter()
+        .map(|sc| {
+            let (lp, ls) = left.get(&sc).map_or((None, None), |&(p, s)| (Some(p), s));
+            let (rp, rs) = right.get(&sc).map_or((None, None), |&(p, s)| (Some(p), s));
+            usize::from(lp != rp) + usize::from(ls != rs)
+        })
+        .sum()
+}
+
+/// Whatever this machine has installed, each keyboard has to describe
+/// as a *whole* keyboard — that is the promise the layout DB relies on
+/// when it replaces a bundled table instead of merging into it.
+#[test]
+fn installed_keyboards_describe_a_full_character_block() {
+    let maps = WindowsLayoutSwitcher::new()
+        .describe_keymaps()
+        .expect("describe the installed keyboards");
+
+    if maps.is_empty() {
+        // A session with no keyboard layouts at all — possible on a
+        // bare CI image. Nothing to assert, and nothing wrong.
+        return;
+    }
+
+    for km in &maps {
+        assert!(
+            km.keys.len() >= 40,
+            "{} ({}) described only {} keys — a real keyboard fills nearly all \
+             {} of the character block",
+            km.id,
+            km.variant,
+            km.keys.len(),
+            CHARACTER_SCANCODES.len()
+        );
+
+        let mut seen = std::collections::HashSet::new();
+        for &(scancode, plain, shift) in &km.keys {
+            assert!(
+                CHARACTER_SCANCODES.contains(&scancode),
+                "{}: 0x{scancode:X} was never asked about",
+                km.id
+            );
+            assert!(
+                seen.insert(scancode),
+                "{}: 0x{scancode:X} described twice — the DB keys a map on this",
+                km.id
+            );
+            assert!(
+                !plain.is_control(),
+                "{}: 0x{scancode:X} produced a control character",
+                km.id
+            );
+            assert_ne!(
+                shift,
+                Some(plain),
+                "{}: 0x{scancode:X} should carry `None` when Shift changes nothing",
+                km.id
+            );
+        }
+    }
+}
+
+/// The measurement behind #20, taken through the shipping code path.
+///
+/// Windows ships three genuinely different Bulgarian keyboards under
+/// one LCID, so all three arrive as `bg-BG` and only one of them can
+/// match `bg_bg.toml`. This is the test that says we can now tell them
+/// apart at all — and prints each table so the numbers in #20 can be
+/// re-derived by diffing against the bundled TOML.
+///
+/// Ignored by default: it loads keymap DLLs into the process and needs
+/// those three keyboards to exist on the machine.
+///
+/// ```text
+/// cargo test -p poltertype-layout -- --ignored --nocapture bulgarian
+/// ```
+#[test]
+#[ignore = "loads keyboard layouts into the process; run by hand"]
+fn the_three_bulgarian_keyboards_describe_differently() {
+    use windows::Win32::UI::Input::KeyboardAndMouse::{KLF_NOTELLSHELL, LoadKeyboardLayoutW};
+    use windows::core::PCWSTR;
+
+    const VARIANTS: &[(&str, &str)] = &[
+        ("00030402", "Phonetic Traditional"),
+        ("00000402", "Typewriter"),
+        ("00040402", "Phonetic"),
+    ];
+
+    let mut described = Vec::new();
+    for (klid, name) in VARIANTS {
+        let wide: Vec<u16> = klid.encode_utf16().chain(std::iter::once(0)).collect();
+        // Safety: `wide` is NUL-terminated and outlives the call.
+        // `KLF_NOTELLSHELL` keeps this process-local — the user's own
+        // keyboard list is not touched.
+        let hkl = unsafe { LoadKeyboardLayoutW(PCWSTR(wide.as_ptr()), KLF_NOTELLSHELL) }
+            .unwrap_or_else(|e| panic!("load Bulgarian {name} ({klid}): {e}"));
+
+        let km = describe_hkl(hkl);
+        println!(
+            "\n--- {klid}  Bulgarian ({name})  {} keys ---",
+            km.keys.len()
+        );
+        let mut rows = km.keys.clone();
+        rows.sort_unstable_by_key(|&(sc, _, _)| sc);
+        for (sc, plain, shift) in rows {
+            match shift {
+                Some(s) => println!("0x{sc:02X} = {{ plain = \"{plain}\", shift = \"{s}\" }}"),
+                None => println!("0x{sc:02X} = {{ plain = \"{plain}\" }}"),
+            }
+        }
+        described.push((*name, km));
+    }
+
+    // The heart of #20: one id, three keyboards.
+    for (name, km) in &described {
+        assert_eq!(
+            km.id,
+            LayoutId::from("bg-BG"),
+            "Bulgarian {name} should still report as bg-BG — that is the whole problem"
+        );
+    }
+
+    let traditional = &described[0].1;
+    let typewriter = &described[1].1;
+    let phonetic = &described[2].1;
+
+    let vs_typewriter = positions_differing(traditional, typewriter);
+    let vs_phonetic = positions_differing(traditional, phonetic);
+    println!("\nPhonetic Traditional vs Typewriter: {vs_typewriter} positions differ");
+    println!("Phonetic Traditional vs Phonetic:   {vs_phonetic} positions differ");
+
+    assert!(
+        vs_typewriter > 0,
+        "Typewriter is a different keyboard and must not describe identically"
+    );
+    assert!(
+        vs_phonetic > 50,
+        "Phonetic differs from Phonetic Traditional across most of the alphabet; \
+         got only {vs_phonetic} differing positions, which means the description \
+         is not variant-aware after all"
+    );
+}

--- a/crates/poltertype-types/src/types.rs
+++ b/crates/poltertype-types/src/types.rs
@@ -32,6 +32,31 @@ impl From<&str> for LayoutId {
     }
 }
 
+/// One keyboard **as the OS itself describes it**, produced by the
+/// platform layout backend and consumed by the layout DB.
+///
+/// [`LayoutId`] names a *language*, which is all the OS layout APIs
+/// agree on — but a language is not a keyboard. Bulgarian alone ships
+/// three genuinely different Windows keyboards under the single id
+/// `bg-BG`, and the bundled mapping can only describe one of them.
+/// Asking the OS what its keys actually produce is the only way to
+/// know which one is installed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OsKeymap {
+    /// The language id this keyboard reports as — the same namespace
+    /// `LayoutSwitcher::current()` and `list_active()` speak in.
+    pub id: LayoutId,
+    /// Opaque per-OS name for the *variant*: which of that language's
+    /// keyboards this is. A Windows KLID (`"00030402"`), free-form
+    /// elsewhere. Logged for diagnosis, never matched on.
+    pub variant: String,
+    /// `(scancode, unshifted, shifted)` for every key that produced a
+    /// printable character. This is the **complete** character table
+    /// for the keyboard: a scancode missing here produces nothing,
+    /// which is why the layout DB replaces rather than merges.
+    pub keys: Vec<(u32, char, Option<char>)>,
+}
+
 /// A raw keyboard event captured by the per-OS listener.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyEvent {

--- a/docs/ADDING_A_LANGUAGE.md
+++ b/docs/ADDING_A_LANGUAGE.md
@@ -85,6 +85,22 @@ loaded user layout layout=pl-PL keys=46 dict=false stem=pl_pl
 If `keys=` is too low, you missed entries. If the layout doesn't
 appear, look for a parse error in the log.
 
+**On Windows, expect the OS to disagree with you — and win.** A
+bundled or plug-in mapping there is replaced by whatever the installed
+keyboard actually produces, because a Windows layout names a language
+and a language is not a keyboard. You will see it happen:
+
+```
+adopted the OS keymap for this keyboard layout=pl-PL variant=00000415 keys=48 replaced=2
+```
+
+That is working as intended, and it means Windows is not the place to
+check a hand-written table — the value you typed into the TOML may
+never be used. A **user** TOML in your config dir still outranks the
+OS, so that is how you test one deliberately. To see exactly which
+keys the OS overruled, run with `RUST_LOG=poltertype_core=debug` and
+read the `keys the OS disagreed on` line.
+
 ---
 
 ## 2. Wordlists (so the dictionary detector recognises the language)

--- a/docs/DATA_LAYOUT.md
+++ b/docs/DATA_LAYOUT.md
@@ -244,10 +244,22 @@ profile set never switches there.
 Order of precedence at load time (last writer wins on `id` collision):
 
 ```
-bundled  ←  plug-ins  ←  user-overlay
+bundled  ←  plug-ins  ←  OS keymaps  ←  user-overlay
 ```
 
 So a user can override a bundled mapping, a plug-in can override a
 bundled one, and a user can override a plug-in. The override is
 explicit — you put a TOML with the same `id` in your config dir and
 restart.
+
+**OS keymaps** are the odd one out: nothing on disk, and only on
+platforms whose layout backend can answer
+`LayoutSwitcher::describe_keymaps()` — today that is Windows alone.
+There a layout is identified by its *language*, so all three of
+Windows' different Bulgarian keyboards arrive as `bg-BG` and a
+bundled table can only be right for one of them. We therefore ask the
+OS what each installed keyboard really produces and replace the key
+table with the answer, keeping the layout's name, script, vowels and
+dictionary — those describe the language, not the keyboard. A user
+TOML still wins, which is the escape hatch if a keyboard is ever read
+wrong. See `docs/DECISIONS.md`, 2026-08-08.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -6,6 +6,67 @@ and any **alternatives** considered.
 
 ---
 
+## 2026-08-08 — Windows keymaps are read from the OS, not declared in a TOML
+
+Closing #20. A Windows layout is identified by its language, so all
+three of Windows' genuinely different Bulgarian keyboards arrive as
+`bg-BG`, and `bg_bg.toml` can only describe one of them. Measured
+through the shipping code path: the bundled table matches Phonetic
+Traditional exactly, differs from Typewriter on 7 keys, and from
+Phonetic on **45 of 48**. Nothing errored — the wrong answer was a
+perfectly well-formed mapping that belonged to somebody else's
+keyboard.
+
+**Decision:** ask the OS. `LayoutSwitcher::describe_keymaps()` is a
+new extension point, defaulting to an empty list; the Windows backend
+implements it with `MapVirtualKeyExW` + `ToUnicodeEx` over each active
+`HKL`, and `LayoutDb` lays the result over the bundled tables.
+
+*Alternative considered — and it is the one the issue itself
+proposed:* an optional `windows_klid` in each TOML, matched against
+the high word of the `HKL`. Rejected. It needs a hand-authored file
+per variant per language, it only ever fixes variants somebody
+remembered to describe, and it leaves custom and third-party layouts
+exactly as broken as before. Querying the OS fixes all of them at
+once and adds no data to maintain. The audit that produced the numbers
+above is also the argument that it is safe: asking Windows reproduces
+the hand-curated `bg_bg.toml` key for key, so the mechanism was
+validated against known-good data before it was trusted with anything.
+
+**Replace, not merge.** `describe_keymaps` promises a *complete*
+table for a fixed block of 48 scancodes, so a scancode asked about and
+missing from the answer is evidence that the key produces nothing —
+not evidence that we failed to ask. Merging would preserve exactly the
+stale rows the whole exercise exists to remove. A floor of 30 keys
+guards against a query that went wrong rather than a keyboard that is
+unusual.
+
+**Precedence: bundled ← plug-ins ← OS ← user.** The OS outranks
+anything we shipped because it is describing the machine rather than
+guessing at it. A user TOML still outranks the OS: it is an explicit
+statement of intent, and it is the escape hatch if this ever reads a
+keyboard wrong.
+
+**Two `ToUnicodeEx` traps, both already paid for once.** It answers
+`-1` for a dead key *and still writes the character*, so reading that
+as "produces nothing" loses every accented key — that mistake was 22
+of the 35 apparent differences in the original audit. And it mutates
+keyboard state, so a pending dead key would compose itself into
+whatever the user types next; we pass the "don't change state" flag
+and drain by hand anyway, because older builds ignore the flag.
+
+**What this does not fix.** Two keyboards for one language still
+collapse to one `LayoutId` and only one table can be held — we keep
+the one currently in effect, else the first the OS lists, which is the
+one Windows activates by default for that language. A user who keeps
+two keyboards for a language *and* types on the second one gets the
+first one's table. Fixing it properly means making `LayoutId` carry
+the variant, which reaches config, the UI, dictionary stems and
+`switch_to`; the user TOML override is the answer until somebody
+actually hits it.
+
+---
+
 ## 2026-08-08 — Undoing a correction teaches the dictionary; the tooltip covers a word's other forms
 
 Three separate holes in "teach PolterType this word", found while


### PR DESCRIPTION
Closes #20.

## The problem

Windows identifies a keyboard layout by its **language**. All three of
Windows' genuinely different Bulgarian keyboards therefore arrive as
`bg-BG`, and `data/layout-mappings/bg_bg.toml` can only be right for
one of them.

Measured on this machine, through the code path that ships:

| Windows keyboard | keys differing from `bg_bg.toml` |
|---|---|
| Bulgarian (Phonetic Traditional) | **0** of 48 |
| Bulgarian (Typewriter) | 7 of 48 |
| Bulgarian (Phonetic) | **45** of 48 |

A user on Bulgarian (Phonetic) got every correction built from a
keyboard they do not own. Nothing errored and nothing showed in the
interface — the wrong answer was a perfectly well-formed mapping that
belonged to somebody else's keyboard. Turkish (Q vs F) and Ukrainian
(standard vs Enhanced) carried the same exposure.

## The fix

`LayoutSwitcher::describe_keymaps()` — a new extension point that
**defaults to an empty list**, so Linux, macOS and every test are
unaffected. The Windows backend implements it with `MapVirtualKeyExW`
+ `ToUnicodeEx` against each active `HKL`; `LayoutDb` lays the answer
over the bundled tables.

Precedence becomes:

```
bundled  ←  plug-ins  ←  OS keymaps  ←  user TOML
```

The OS outranks anything we shipped because it describes the machine
rather than guessing at it. A user TOML still outranks the OS — that
is the escape hatch if a keyboard is ever read wrong, and it is
covered by a test.

Only the **key table** is replaced. Name, script, vowels and
dictionary describe the *language*, not the keyboard, and survive.

### Why query rather than declare

#20 proposed an optional `windows_klid` in each TOML, matched against
the high word of the `HKL`. This does the other thing, deliberately:

- it fixes **every** keyboard, including custom and third-party
  layouts nobody could have written a file for;
- it adds no data to maintain — no file per variant per language;
- asking Windows reproduces the hand-curated `bg_bg.toml` key for key,
  so the mechanism was validated against known-good data before being
  trusted with anything else.

### Side effect worth knowing about

`uk-UA` `0x2B` was one of four keys where Windows and xkb genuinely
disagree, left alone because one TOML serves three operating systems.
It resolves itself here: Windows users now get `\` on `0x2B` and `ґ`
back on `0x56`, where Windows actually keeps it, while Linux reads the
unchanged TOML. The Ukrainian apostrophe and hryvnia sign — missing
from the bundled table entirely — came along too.

## Verification

- `the_three_bulgarian_keyboards_describe_differently` — ignored by
  default, loads the three real Bulgarian keymaps and asserts they
  describe differently. It prints each table, which is how the numbers
  above were re-derived.
- `installed_keyboards_describe_a_full_character_block` — runs on
  every Windows build against whatever the machine has.
- Five loader tests in `poltertype-core` covering replace-not-merge,
  the sparse-keymap floor, unknown languages, duplicate languages, and
  user-TOML precedence.
- End-to-end on this machine: the app adopts all three of its
  keyboards at startup, `dropped=0` on every one.
- Full suite, both clippy passes, fmt.

## Two `ToUnicodeEx` traps, both handled at the call site

- It answers **-1 for a dead key and still writes the character**.
  Reading that as "produces nothing" loses every accented key — it was
  22 of the 35 apparent differences in the original audit.
- It **mutates keyboard state**, so a pending dead key would compose
  itself into whatever the user types next. We pass the
  don't-change-state flag and drain by hand anyway, because older
  builds ignore it.

## What this does not fix

Two keyboards for one language still collapse to one `LayoutId` and
only one table can be held. We keep the one currently in effect, else
the first the OS lists — which is the one Windows activates by default
for that language. A user who keeps two keyboards for a language *and*
types on the second gets the first one's table; a user TOML is the
answer until somebody actually hits it. Fixing it properly means
putting the variant into `LayoutId`, which reaches config, the UI,
dictionary stems and `switch_to`.

Recorded in `docs/DECISIONS.md` (2026-08-08) and in the Known gaps
list, rather than left for the next person to rediscover.
