### PR TITLE
macOS: add non-activating spelling suggestion popup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,6 +1231,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -3387,8 +3389,8 @@ dependencies = [
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
- "objc2-core-data",
- "objc2-core-image",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-quartz-core 0.2.2",
 ]
@@ -3400,9 +3402,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -3416,6 +3427,17 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3439,6 +3461,17 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3474,7 +3507,17 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3487,6 +3530,31 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3557,6 +3625,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3566,7 +3645,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -3576,9 +3655,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-video",
  "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -3600,9 +3684,9 @@ dependencies = [
  "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-image",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
@@ -4074,6 +4158,8 @@ dependencies = [
  "directories",
  "evdev",
  "libc",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "parking_lot 0.12.5",
  "poltertype-types",
  "thiserror 1.0.69",
@@ -4099,8 +4185,15 @@ dependencies = [
 name = "poltertype-popup"
 version = "0.14.4"
 dependencies = [
+ "block2 0.6.2",
+ "core-graphics 0.25.0",
  "cosmic-text",
  "crossbeam-channel",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "smithay-client-toolkit 0.19.2",
  "thiserror 1.0.69",
  "tiny-skia",

--- a/crates/poltertype-app/src/main.rs
+++ b/crates/poltertype-app/src/main.rs
@@ -920,7 +920,17 @@ fn init_tracing() -> Option<tracing_appender::non_blocking::WorkerGuard> {
     use tracing_subscriber::util::SubscriberInitExt;
     use tracing_subscriber::{EnvFilter, fmt};
 
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    // cosmic-text / fontdb log the *text being shaped* at debug level
+    // ("Failed to find script fallback …: '<word>'") — and the
+    // suggestion tooltip shapes the user's words. Those targets are
+    // capped at warn no matter what RUST_LOG says: typed text stays
+    // out of the logs at any level.
+    let mut filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    for target in ["cosmic_text=warn", "fontdb=warn"] {
+        if let Ok(directive) = target.parse() {
+            filter = filter.add_directive(directive);
+        }
+    }
 
     let stderr_layer = fmt::layer().with_writer(std::io::stderr).with_target(false);
 

--- a/crates/poltertype-input/Cargo.toml
+++ b/crates/poltertype-input/Cargo.toml
@@ -36,6 +36,13 @@ core-foundation     = "0.10"
 # `None` back into the original event, so an "active" tap swallowed
 # nothing and the key gate doubled the user's keystrokes.
 core-graphics       = "0.25"
+# `proc_pidpath` — the focused-exe half of the AX focus tracker.
+libc                = "0.2"
+# NSWorkspace.frontmostApplication — the reliable way to find the
+# focused app's pid (the system-wide AX element is not, on real
+# machines). Used by the focus tracker only.
+objc2               = "0.6"
+objc2-app-kit       = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Wayland-first: evdev requires the user to be in the `input` group.

--- a/crates/poltertype-input/src/focus/factory.rs
+++ b/crates/poltertype-input/src/focus/factory.rs
@@ -15,7 +15,11 @@ pub fn create_focus_tracker() -> Arc<dyn FocusTracker> {
     {
         linux_impl::create_linux_focus_tracker()
     }
-    #[cfg(not(any(windows, target_os = "linux")))]
+    #[cfg(target_os = "macos")]
+    {
+        std::sync::Arc::new(macos_impl::MacosFocusTracker)
+    }
+    #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
     {
         Arc::new(NoopFocusTracker)
     }

--- a/crates/poltertype-input/src/focus/macos_impl.rs
+++ b/crates/poltertype-input/src/focus/macos_impl.rs
@@ -66,9 +66,17 @@ const K_AXVALUE_TYPE_CFRANGE: u32 = 4;
 /// that cannot answer within this is treated as one without a11y.
 const AX_MSG_TIMEOUT_SECS: f32 = 0.3;
 
-/// A caret thinner than this many points is no caret — it is the
-/// zero-size junk rect several apps hand back instead.
-const MIN_CARET_HEIGHT: f64 = 2.0;
+/// A caret with zero height is no caret — it is the empty junk rect
+/// several apps hand back instead. The cap filters the other extreme
+/// (a whole-line "selection bounds" answer).
+const MIN_CARET_HEIGHT: f64 = 0.5;
+const MAX_CARET_HEIGHT: f64 = 120.0;
+
+/// Retry budget for the focused-element query: it can race the target
+/// app's own focus-change handling and answer `cannotComplete` /
+/// `noValue` transiently (SuperDictate's resolver does the same).
+const FOCUS_RETRY_ATTEMPTS: usize = 3;
+const FOCUS_RETRY_DELAY: Duration = Duration::from_millis(40);
 
 /// Slack for the "caret belongs to its element" check: real carets
 /// stick out of the field's frame by a few points (TextEdit's search
@@ -155,6 +163,51 @@ fn ax_value<T: Copy>(value: CFTypeRef, value_type: u32) -> Option<T> {
     if ok { Some(out) } else { None }
 }
 
+/// A parameterized attribute whose answer is an AXValue-wrapped
+/// CGRect (`kAXBoundsForRange`, `AXBoundsForTextMarkerRange`).
+fn parameterized_rect(element: CFTypeRef, name: &'static str, parameter: CFTypeRef) -> Option<CGRect> {
+    let attr = CFString::from_static_string(name);
+    let mut bounds: CFTypeRef = std::ptr::null();
+    // Safety: live element, live parameter, out-pointer is ours.
+    let err = unsafe {
+        AXUIElementCopyParameterizedAttributeValue(
+            element,
+            attr.as_concrete_TypeRef(),
+            parameter,
+            &mut bounds,
+        )
+    };
+    if err != 0 || bounds.is_null() {
+        return None;
+    }
+    let bounds = OwnedCF(bounds);
+    ax_value::<CGRect>(bounds.0, K_AXVALUE_TYPE_CGRECT)
+}
+
+/// Copy an attribute with the transient-error retry — see
+/// `FOCUS_RETRY_ATTEMPTS`.
+fn copy_attr_retry(element: CFTypeRef, name: &'static str) -> Option<OwnedCF> {
+    for attempt in 0..FOCUS_RETRY_ATTEMPTS {
+        let attr = CFString::from_static_string(name);
+        let mut value: CFTypeRef = std::ptr::null();
+        // Safety: as in `copy_attr`.
+        let err =
+            unsafe { AXUIElementCopyAttributeValue(element, attr.as_concrete_TypeRef(), &mut value) };
+        if err == 0 && !value.is_null() {
+            return Some(OwnedCF(value));
+        }
+        // kAXErrorCannotComplete / kAXErrorNoValue: transient — the
+        // app's own focus handling is mid-flight. Anything else will
+        // fail the same way again; don't burn the budget on it.
+        let transient = err == -25204 || err == -25212;
+        if !transient || attempt + 1 == FOCUS_RETRY_ATTEMPTS {
+            return None;
+        }
+        std::thread::sleep(FOCUS_RETRY_DELAY);
+    }
+    None
+}
+
 /// `AXPosition` + `AXSize` of an element as one rect, when it has both.
 fn element_frame(element: CFTypeRef) -> Option<CGRect> {
     let origin =
@@ -203,52 +256,67 @@ impl MacosFocusTracker {
         element_frame(window.0)
     }
 
-    /// What `kAXBoundsForRange` says about the caret, unvalidated.
+    /// What the caret APIs say, unvalidated. The marker-range pair
+    /// (`AXSelectedTextMarkerRange` → `AXBoundsForTextMarkerRange`)
+    /// goes first: WebKit implements it properly where the plain
+    /// range pair answers junk. The plain pair is then tried with the
+    /// selection as-is and with its length clamped to ≥ 1 — some apps
+    /// only answer non-empty ranges.
     fn raw_caret_bounds(element: CFTypeRef) -> Option<CGRect> {
+        if let Some(marker) = copy_attr(element, "AXSelectedTextMarkerRange") {
+            if let Some(rect) =
+                parameterized_rect(element, "AXBoundsForTextMarkerRange", marker.0)
+            {
+                return Some(rect);
+            }
+        }
         let range_value = copy_attr(element, "AXSelectedTextRange")?;
         let range = ax_value::<CFRange>(range_value.0, K_AXVALUE_TYPE_CFRANGE)?;
-
-        // kAXBoundsForRange is parameterized: the range goes back in
-        // wrapped in a new AXValue, the answer comes out as a CGRect
-        // in global screen coordinates.
-        // Safety: `range` outlives the Create call; Create rule — the
-        // result is ours (OwnedCF).
-        let param = unsafe {
-            AXValueCreate(
-                K_AXVALUE_TYPE_CFRANGE,
-                std::ptr::from_ref(&range).cast::<c_void>(),
-            )
-        };
-        if param.is_null() {
-            return None;
+        for candidate in [
+            range,
+            CFRange {
+                location: range.location,
+                length: range.length.max(1),
+            },
+        ] {
+            // kAXBoundsForRange is parameterized: the range goes back
+            // in wrapped in a new AXValue, the answer comes out as a
+            // CGRect in global screen coordinates.
+            // Safety: `candidate` outlives the Create call; Create
+            // rule — the result is ours (OwnedCF).
+            let param = unsafe {
+                AXValueCreate(
+                    K_AXVALUE_TYPE_CFRANGE,
+                    std::ptr::from_ref(&candidate).cast::<c_void>(),
+                )
+            };
+            if param.is_null() {
+                continue;
+            }
+            let param = OwnedCF(param);
+            if let Some(rect) = parameterized_rect(element, "AXBoundsForRange", param.0) {
+                return Some(rect);
+            }
         }
-        let param = OwnedCF(param);
-
-        let attr = CFString::from_static_string("AXBoundsForRange");
-        let mut bounds: CFTypeRef = std::ptr::null();
-        // Safety: live element, live parameter, out-pointer is ours.
-        let err = unsafe {
-            AXUIElementCopyParameterizedAttributeValue(
-                element,
-                attr.as_concrete_TypeRef(),
-                param.0,
-                &mut bounds,
-            )
-        };
-        if err != 0 || bounds.is_null() {
-            return None;
-        }
-        let bounds = OwnedCF(bounds);
-        ax_value::<CGRect>(bounds.0, K_AXVALUE_TYPE_CGRECT)
+        None
     }
 
     /// Is `rect` a believable caret for an element whose frame is
     /// `frame`? See the module docs — several apps hand back junk
     /// here, and a wrong caret anchors the tooltip to wherever the
     /// caret *previously* was, which reads as "the tooltip follows
-    /// the old field".
+    /// the old field". A real caret is a thin sliver one line tall,
+    /// in the neighbourhood of its element.
     fn caret_is_sane(rect: CGRect, frame: Option<CGRect>) -> bool {
-        if rect.size.height < MIN_CARET_HEIGHT {
+        let (w, h) = (rect.size.width, rect.size.height);
+        if !rect.origin.x.is_finite() || !rect.origin.y.is_finite() || !w.is_finite() || !h.is_finite()
+        {
+            return false;
+        }
+        if !(MIN_CARET_HEIGHT..=MAX_CARET_HEIGHT).contains(&h) {
+            return false;
+        }
+        if w < 0.0 || w > 12.0_f64.max(h * 1.5) {
             return false;
         }
         let Some(f) = frame else { return true };
@@ -318,7 +386,9 @@ impl FocusTracker for MacosFocusTracker {
 
     fn caret_hint(&self) -> Option<CaretHint> {
         let app = Self::app_element()?;
-        let element = copy_attr(app.0, "AXFocusedUIElement")?;
+        // The one query that races the target's own focus handling —
+        // worth the retry budget.
+        let element = copy_attr_retry(app.0, "AXFocusedUIElement")?;
         let window = Self::focused_window_rect()?;
         let frame = element_frame(element.0);
 

--- a/crates/poltertype-input/src/focus/macos_impl.rs
+++ b/crates/poltertype-input/src/focus/macos_impl.rs
@@ -1,0 +1,349 @@
+//! macOS focus tracking: Accessibility (HIServices) queries.
+//!
+//! The chain mirrors the Windows tracker's, with AX objects standing
+//! in for HWNDs:
+//!
+//! * focused exe — `NSWorkspace.frontmostApplication` → pid →
+//!   `proc_pidpath` → basename.
+//! * focused window geometry — pid's app element →
+//!   `kAXFocusedWindow` → `kAXPosition` / `kAXSize`.
+//! * caret — app element's `kAXFocusedUIElement` →
+//!   `kAXSelectedTextRange` → parameterized `kAXBoundsForRange`,
+//!   **validated** (see below); when the caret bounds are garbage,
+//!   the focused element's own frame is the anchor.
+//!
+//! ## Why the pid path, not the system-wide element
+//!
+//! `AXUIElementCreateSystemWide` + `kAXFocusedApplication` is the
+//! textbook route — and on this project's test machine it answers
+//! `kAXErrorCannotComplete` essentially always, while the same query
+//! on an app element built from the frontmost pid answers instantly.
+//! (Diagnosed 2026-08-10 on macOS 15.7, Intel; the system-wide
+//! element is simply not trustworthy here.)
+//!
+//! ## Why the caret answer must be validated
+//!
+//! Real carets (TextEdit, native fields) come back as a thin rect
+//! with a line's height. Chrome — omnibox *and* web inputs — and
+//! Terminal.app return junk instead: a zero-size rect at the web
+//! area's origin, or a point beyond the window's bottom edge. A
+//! caret with no height is not a caret, and a caret outside the
+//! element it claims to be in is lying; both are rejected, and the
+//! focused element's frame (always correct in those apps — it is how
+//! the omnibox anchor still lands on the address bar) takes over.
+//!
+//! Everything here needs the Accessibility permission the app's
+//! `CGEventTap` listener already requires; a denied query maps to
+//! `None` and the caller degrades to a coarser anchor. Queries carry
+//! an explicit messaging timeout: this runs on the UI event loop at
+//! tooltip-show time, and an unresponsive target app must not freeze
+//! it for the multi-second AX default.
+//!
+//! The FFI is declared by hand (the same pattern as
+//! `macos/listener.rs`'s `CFMachPortCreateRunLoopSource`) because the
+//! `core-foundation` crate stops at CF and does not wrap HIServices.
+
+use std::ffi::CStr;
+use std::ffi::c_void;
+use std::path::Path;
+use std::time::Duration;
+
+use core_foundation::base::{CFGetTypeID, CFRelease, CFTypeRef, TCFType};
+use core_foundation::string::{CFString, CFStringGetTypeID, CFStringRef};
+use core_graphics::geometry::{CGPoint, CGRect, CGSize};
+use objc2_app_kit::NSWorkspace;
+
+use super::traits::FocusTracker;
+use super::types::{CaretHint, FocusedWindowGeometry};
+
+// AXValueType constants from HIServices/AXValue.h.
+const K_AXVALUE_TYPE_CGPOINT: u32 = 1;
+const K_AXVALUE_TYPE_CGSIZE: u32 = 2;
+const K_AXVALUE_TYPE_CGRECT: u32 = 3;
+const K_AXVALUE_TYPE_CFRANGE: u32 = 4;
+
+/// Cap on how long one AX query may block the UI event loop. An app
+/// that cannot answer within this is treated as one without a11y.
+const AX_MSG_TIMEOUT_SECS: f32 = 0.3;
+
+/// A caret thinner than this many points is no caret — it is the
+/// zero-size junk rect several apps hand back instead.
+const MIN_CARET_HEIGHT: f64 = 2.0;
+
+/// Slack for the "caret belongs to its element" check: real carets
+/// stick out of the field's frame by a few points (TextEdit's search
+/// field reports one 9 pt above its frame), Chrome's junk is hundreds
+/// of points away.
+const CARET_FRAME_SLACK: f64 = 24.0;
+
+/// `CFRange` from CFBase — declared locally rather than pulling in
+/// `core-foundation-sys` for one struct.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct CFRange {
+    location: isize,
+    length: isize,
+}
+
+#[link(name = "ApplicationServices", kind = "framework")]
+unsafe extern "C" {
+    fn AXUIElementCreateApplication(pid: libc::pid_t) -> CFTypeRef;
+    fn AXUIElementCopyAttributeValue(
+        element: CFTypeRef,
+        attribute: CFStringRef,
+        value: *mut CFTypeRef,
+    ) -> i32;
+    fn AXUIElementCopyParameterizedAttributeValue(
+        element: CFTypeRef,
+        attribute: CFStringRef,
+        parameter: CFTypeRef,
+        value: *mut CFTypeRef,
+    ) -> i32;
+    fn AXUIElementSetMessagingTimeout(element: CFTypeRef, seconds: f32) -> i32;
+    fn AXValueCreate(value_type: u32, value_ptr: *const c_void) -> CFTypeRef;
+    fn AXValueGetValue(value: CFTypeRef, value_type: u32, value_ptr: *mut c_void) -> bool;
+}
+
+/// An owned AX/CF reference — every successful `Copy`/`Create` call
+/// above hands us a +1 object, and this is the single place it goes
+/// back.
+struct OwnedCF(CFTypeRef);
+
+impl Drop for OwnedCF {
+    fn drop(&mut self) {
+        // Safety: balancing the +1 from the Copy/Create call this
+        // wrapper was built from; never constructed from a null.
+        unsafe { CFRelease(self.0) }
+    }
+}
+
+/// Copy an attribute, or `None` on any AX error (no permission, no
+/// focused element, app without a11y — all mean "degrade gracefully").
+fn copy_attr(element: CFTypeRef, name: &'static str) -> Option<OwnedCF> {
+    let attr = CFString::from_static_string(name);
+    let mut value: CFTypeRef = std::ptr::null();
+    // Safety: `element` is a live AX object, `value` is ours to fill.
+    let err =
+        unsafe { AXUIElementCopyAttributeValue(element, attr.as_concrete_TypeRef(), &mut value) };
+    if err != 0 || value.is_null() {
+        return None;
+    }
+    Some(OwnedCF(value))
+}
+
+/// Copy a string attribute (role names and the like).
+fn copy_string_attr(element: CFTypeRef, name: &'static str) -> Option<String> {
+    let value = copy_attr(element, name)?;
+    // Safety: `value` is a live CF object we own; the type check keeps
+    // a non-string answer from being read as one. Get-rule wrap: the
+    // +1 stays with `value` (dropped below), the CFString wrapper
+    // retains its own.
+    unsafe {
+        if CFGetTypeID(value.0) != CFStringGetTypeID() {
+            return None;
+        }
+        Some(CFString::wrap_under_get_rule(value.0.cast()).to_string())
+    }
+}
+
+/// Unwrap an AXValue into its C payload.
+fn ax_value<T: Copy>(value: CFTypeRef, value_type: u32) -> Option<T> {
+    let mut out: T = unsafe { std::mem::zeroed() };
+    // Safety: `out` is the exact payload type `value_type` promises to
+    // write, and `value` is a live AXValue we own.
+    let ok = unsafe { AXValueGetValue(value, value_type, std::ptr::from_mut(&mut out).cast()) };
+    if ok { Some(out) } else { None }
+}
+
+/// `AXPosition` + `AXSize` of an element as one rect, when it has both.
+fn element_frame(element: CFTypeRef) -> Option<CGRect> {
+    let origin =
+        copy_attr(element, "AXPosition").and_then(|v| ax_value::<CGPoint>(v.0, K_AXVALUE_TYPE_CGPOINT))?;
+    let size =
+        copy_attr(element, "AXSize").and_then(|v| ax_value::<CGSize>(v.0, K_AXVALUE_TYPE_CGSIZE))?;
+    Some(CGRect::new(&origin, &size))
+}
+
+pub struct MacosFocusTracker;
+
+impl MacosFocusTracker {
+    /// The frontmost application's pid — `NSWorkspace` answers this
+    /// without any AX traffic at all.
+    fn frontmost_pid() -> Option<libc::pid_t> {
+        let pid = NSWorkspace::sharedWorkspace()
+            .frontmostApplication()?
+            .processIdentifier();
+        if pid > 0 { Some(pid) } else { None }
+    }
+
+    /// The frontmost app's AX element, with the messaging timeout
+    /// already clamped — every query below goes through it.
+    fn app_element() -> Option<OwnedCF> {
+        let pid = Self::frontmost_pid()?;
+        // Safety: creating a reference for a live pid. The result is
+        // non-null even for apps that later refuse to answer; those
+        // fail at query time, not here.
+        let element = unsafe { AXUIElementCreateApplication(pid) };
+        if element.is_null() {
+            return None;
+        }
+        let owned = OwnedCF(element);
+        // Safety: live element; a failure only means queries keep the
+        // default (long) timeout — not worth failing the tracker over.
+        unsafe { AXUIElementSetMessagingTimeout(owned.0, AX_MSG_TIMEOUT_SECS) };
+        Some(owned)
+    }
+
+    /// The focused window's global rect — the shared tail of
+    /// `focused_window_geometry` and `caret_hint` (which reports
+    /// window-relative coordinates).
+    fn focused_window_rect() -> Option<CGRect> {
+        let app = Self::app_element()?;
+        let window = copy_attr(app.0, "AXFocusedWindow")?;
+        element_frame(window.0)
+    }
+
+    /// What `kAXBoundsForRange` says about the caret, unvalidated.
+    fn raw_caret_bounds(element: CFTypeRef) -> Option<CGRect> {
+        let range_value = copy_attr(element, "AXSelectedTextRange")?;
+        let range = ax_value::<CFRange>(range_value.0, K_AXVALUE_TYPE_CFRANGE)?;
+
+        // kAXBoundsForRange is parameterized: the range goes back in
+        // wrapped in a new AXValue, the answer comes out as a CGRect
+        // in global screen coordinates.
+        // Safety: `range` outlives the Create call; Create rule — the
+        // result is ours (OwnedCF).
+        let param = unsafe {
+            AXValueCreate(
+                K_AXVALUE_TYPE_CFRANGE,
+                std::ptr::from_ref(&range).cast::<c_void>(),
+            )
+        };
+        if param.is_null() {
+            return None;
+        }
+        let param = OwnedCF(param);
+
+        let attr = CFString::from_static_string("AXBoundsForRange");
+        let mut bounds: CFTypeRef = std::ptr::null();
+        // Safety: live element, live parameter, out-pointer is ours.
+        let err = unsafe {
+            AXUIElementCopyParameterizedAttributeValue(
+                element,
+                attr.as_concrete_TypeRef(),
+                param.0,
+                &mut bounds,
+            )
+        };
+        if err != 0 || bounds.is_null() {
+            return None;
+        }
+        let bounds = OwnedCF(bounds);
+        ax_value::<CGRect>(bounds.0, K_AXVALUE_TYPE_CGRECT)
+    }
+
+    /// Is `rect` a believable caret for an element whose frame is
+    /// `frame`? See the module docs — several apps hand back junk
+    /// here, and a wrong caret anchors the tooltip to wherever the
+    /// caret *previously* was, which reads as "the tooltip follows
+    /// the old field".
+    fn caret_is_sane(rect: CGRect, frame: Option<CGRect>) -> bool {
+        if rect.size.height < MIN_CARET_HEIGHT {
+            return false;
+        }
+        let Some(f) = frame else { return true };
+        let near = CGRect::new(
+            &CGPoint::new(
+                f.origin.x - CARET_FRAME_SLACK,
+                f.origin.y - CARET_FRAME_SLACK,
+            ),
+            &CGSize::new(
+                f.size.width + 2.0 * CARET_FRAME_SLACK,
+                f.size.height + 2.0 * CARET_FRAME_SLACK,
+            ),
+        );
+        rect.is_intersects(&near)
+    }
+
+    /// Roles whose frame is a good tooltip anchor when the caret is
+    /// unavailable or junk — text entry widgets. (The search field is
+    /// an `AXTextField` subrole, the omnibox a plain `AXTextField`.)
+    fn is_text_role(element: CFTypeRef) -> bool {
+        matches!(
+            copy_string_attr(element, "AXRole").as_deref(),
+            Some("AXTextField") | Some("AXTextArea") | Some("AXComboBox")
+        )
+    }
+
+    /// Global rect → window-relative hint.
+    fn hint_from(rect: CGRect, window: CGRect) -> CaretHint {
+        CaretHint {
+            x: rect.origin.x as i32 - window.origin.x as i32,
+            y: rect.origin.y as i32 - window.origin.y as i32,
+            height: rect.size.height as u32,
+            // A live query, not a cached sample — always fresh.
+            age: Duration::ZERO,
+        }
+    }
+}
+
+impl FocusTracker for MacosFocusTracker {
+    fn focused_exe(&self) -> Option<String> {
+        let pid = Self::frontmost_pid()?;
+        let mut buf = [0i8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
+        // Safety: `buf` is a valid writable buffer of the given size.
+        let len = unsafe { libc::proc_pidpath(pid, buf.as_mut_ptr().cast(), buf.len() as u32) };
+        if len <= 0 {
+            return None;
+        }
+        let path = unsafe { CStr::from_ptr(buf.as_ptr()) }.to_string_lossy();
+        let name = Path::new(path.as_ref()).file_name()?.to_string_lossy().into_owned();
+        Some(name)
+    }
+
+    fn focused_window_geometry(&self) -> Option<FocusedWindowGeometry> {
+        let rect = Self::focused_window_rect()?;
+        Some(FocusedWindowGeometry {
+            x: rect.origin.x as i32,
+            y: rect.origin.y as i32,
+            width: rect.size.width as u32,
+            height: rect.size.height as u32,
+            // Global top-left coordinates are already global on macOS;
+            // the output fields are a Wayland-only concern.
+            output: None,
+            output_x: 0,
+            output_y: 0,
+        })
+    }
+
+    fn caret_hint(&self) -> Option<CaretHint> {
+        let app = Self::app_element()?;
+        let element = copy_attr(app.0, "AXFocusedUIElement")?;
+        let window = Self::focused_window_rect()?;
+        let frame = element_frame(element.0);
+
+        // Best: a caret that passes the sanity check (native apps).
+        if let Some(rect) = Self::raw_caret_bounds(element.0)
+            && Self::caret_is_sane(rect, frame)
+        {
+            return Some(Self::hint_from(rect, window));
+        }
+
+        // Next: the focused element's own frame, when the element is a
+        // text widget — this is the Chrome/Terminal path, where the
+        // caret answer is junk but the field's frame is exact.
+        if Self::is_text_role(element.0)
+            && let Some(f) = frame
+            && f.size.width > 1.0
+            && f.size.height > 1.0
+        {
+            return Some(Self::hint_from(f, window));
+        }
+
+        None
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "macos-ax"
+    }
+}

--- a/crates/poltertype-input/src/focus/macos_impl.rs
+++ b/crates/poltertype-input/src/focus/macos_impl.rs
@@ -165,7 +165,11 @@ fn ax_value<T: Copy>(value: CFTypeRef, value_type: u32) -> Option<T> {
 
 /// A parameterized attribute whose answer is an AXValue-wrapped
 /// CGRect (`kAXBoundsForRange`, `AXBoundsForTextMarkerRange`).
-fn parameterized_rect(element: CFTypeRef, name: &'static str, parameter: CFTypeRef) -> Option<CGRect> {
+fn parameterized_rect(
+    element: CFTypeRef,
+    name: &'static str,
+    parameter: CFTypeRef,
+) -> Option<CGRect> {
     let attr = CFString::from_static_string(name);
     let mut bounds: CFTypeRef = std::ptr::null();
     // Safety: live element, live parameter, out-pointer is ours.
@@ -191,8 +195,9 @@ fn copy_attr_retry(element: CFTypeRef, name: &'static str) -> Option<OwnedCF> {
         let attr = CFString::from_static_string(name);
         let mut value: CFTypeRef = std::ptr::null();
         // Safety: as in `copy_attr`.
-        let err =
-            unsafe { AXUIElementCopyAttributeValue(element, attr.as_concrete_TypeRef(), &mut value) };
+        let err = unsafe {
+            AXUIElementCopyAttributeValue(element, attr.as_concrete_TypeRef(), &mut value)
+        };
         if err == 0 && !value.is_null() {
             return Some(OwnedCF(value));
         }
@@ -210,10 +215,10 @@ fn copy_attr_retry(element: CFTypeRef, name: &'static str) -> Option<OwnedCF> {
 
 /// `AXPosition` + `AXSize` of an element as one rect, when it has both.
 fn element_frame(element: CFTypeRef) -> Option<CGRect> {
-    let origin =
-        copy_attr(element, "AXPosition").and_then(|v| ax_value::<CGPoint>(v.0, K_AXVALUE_TYPE_CGPOINT))?;
-    let size =
-        copy_attr(element, "AXSize").and_then(|v| ax_value::<CGSize>(v.0, K_AXVALUE_TYPE_CGSIZE))?;
+    let origin = copy_attr(element, "AXPosition")
+        .and_then(|v| ax_value::<CGPoint>(v.0, K_AXVALUE_TYPE_CGPOINT))?;
+    let size = copy_attr(element, "AXSize")
+        .and_then(|v| ax_value::<CGSize>(v.0, K_AXVALUE_TYPE_CGSIZE))?;
     Some(CGRect::new(&origin, &size))
 }
 
@@ -264,8 +269,7 @@ impl MacosFocusTracker {
     /// only answer non-empty ranges.
     fn raw_caret_bounds(element: CFTypeRef) -> Option<CGRect> {
         if let Some(marker) = copy_attr(element, "AXSelectedTextMarkerRange") {
-            if let Some(rect) =
-                parameterized_rect(element, "AXBoundsForTextMarkerRange", marker.0)
+            if let Some(rect) = parameterized_rect(element, "AXBoundsForTextMarkerRange", marker.0)
             {
                 return Some(rect);
             }
@@ -309,7 +313,10 @@ impl MacosFocusTracker {
     /// in the neighbourhood of its element.
     fn caret_is_sane(rect: CGRect, frame: Option<CGRect>) -> bool {
         let (w, h) = (rect.size.width, rect.size.height);
-        if !rect.origin.x.is_finite() || !rect.origin.y.is_finite() || !w.is_finite() || !h.is_finite()
+        if !rect.origin.x.is_finite()
+            || !rect.origin.y.is_finite()
+            || !w.is_finite()
+            || !h.is_finite()
         {
             return false;
         }
@@ -365,7 +372,10 @@ impl FocusTracker for MacosFocusTracker {
             return None;
         }
         let path = unsafe { CStr::from_ptr(buf.as_ptr()) }.to_string_lossy();
-        let name = Path::new(path.as_ref()).file_name()?.to_string_lossy().into_owned();
+        let name = Path::new(path.as_ref())
+            .file_name()?
+            .to_string_lossy()
+            .into_owned();
         Some(name)
     }
 

--- a/crates/poltertype-input/src/focus/mod.rs
+++ b/crates/poltertype-input/src/focus/mod.rs
@@ -16,6 +16,9 @@ mod windows_impl;
 #[cfg(target_os = "linux")]
 mod linux_impl;
 
+#[cfg(target_os = "macos")]
+mod macos_impl;
+
 mod factory;
 mod noop;
 mod traits;

--- a/crates/poltertype-input/src/macos/emitter.rs
+++ b/crates/poltertype-input/src/macos/emitter.rs
@@ -27,6 +27,18 @@ use crate::{InputError, KeyEmitter, Modifiers};
 /// for the same reason.
 const MODIFIER_SETTLE: Duration = Duration::from_millis(4);
 
+/// Gap between individual key events inside one burst.
+///
+/// The hazard the `MODIFIER_SETTLE` comment above describes applies
+/// to key events too, and harder: a backspace burst posted
+/// back-to-back reaches the focused app within a single run-loop
+/// turn, and AppKit coalesces same-key down/up pairs that share a
+/// timestamp — observably, one delete in six was landing, which left
+/// the mistyped word's first letter on screen ahead of the
+/// replacement (and one *extra* landing delete ate the separator
+/// before the word). 2 ms matches the X11 emitter's `KEY_STEP`.
+const KEY_STEP: Duration = Duration::from_millis(2);
+
 pub struct MacosEmitter;
 
 impl MacosEmitter {
@@ -69,7 +81,9 @@ impl KeyEmitter for MacosEmitter {
         let src = event_source()?;
         for _ in 0..n {
             keyboard_event(&src, KVK_DELETE, true)?.post(CGEventTapLocation::HID);
+            std::thread::sleep(KEY_STEP);
             keyboard_event(&src, KVK_DELETE, false)?.post(CGEventTapLocation::HID);
+            std::thread::sleep(KEY_STEP);
         }
         Ok(())
     }
@@ -85,6 +99,7 @@ impl KeyEmitter for MacosEmitter {
                 let ev = keyboard_event(&src, 0, key_down)?;
                 ev.set_string_from_utf16_unchecked(&utf16);
                 ev.post(CGEventTapLocation::HID);
+                std::thread::sleep(KEY_STEP);
             }
         }
         Ok(())

--- a/crates/poltertype-popup/Cargo.toml
+++ b/crates/poltertype-popup/Cargo.toml
@@ -36,3 +36,16 @@ windows = { version = "0.58", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_LibraryLoader",
 ] }
+
+# macOS overlay: an NSPanel driven entirely on the main dispatch queue
+# (AppKit's hard rule), pixels handed over as a CGImage built from the
+# shared renderer's premultiplied RGBA — same family of crates tao and
+# poltertype-input already link, so no second ObjC runtime copy.
+[target.'cfg(target_os = "macos")'.dependencies]
+block2            = "0.6"
+core-graphics     = "0.25"
+dispatch2         = "0.3"
+objc2             = "0.6"
+objc2-app-kit     = "0.3"
+objc2-foundation  = "0.3"
+objc2-quartz-core = "0.3"

--- a/crates/poltertype-popup/src/factory.rs
+++ b/crates/poltertype-popup/src/factory.rs
@@ -4,6 +4,9 @@ use crossbeam_channel::Sender;
 use tracing::info;
 
 use crate::enums::PopupUiEvent;
+// macOS is the one lane where every platform has a real backend, so
+// the fallback stays out of that build entirely.
+#[cfg(not(target_os = "macos"))]
 use crate::noop::NoopPopup;
 use crate::traits::SuggestionPopup;
 
@@ -59,7 +62,16 @@ fn create_for_platform(events: Sender<PopupUiEvent>) -> Box<dyn SuggestionPopup>
     }
 }
 
-#[cfg(not(any(target_os = "linux", windows)))]
+/// macOS gets the `NSPanel` backend. It cannot fail at construction:
+/// the panel is created lazily on the first `show`, because
+/// `create_popup` runs before the tao event loop starts pumping the
+/// main queue that every AppKit call must hop to.
+#[cfg(target_os = "macos")]
+fn create_for_platform(events: Sender<PopupUiEvent>) -> Box<dyn SuggestionPopup> {
+    Box::new(crate::macos::MacosPopup::new(events))
+}
+
+#[cfg(not(any(target_os = "linux", windows, target_os = "macos")))]
 fn create_for_platform(_events: Sender<PopupUiEvent>) -> Box<dyn SuggestionPopup> {
     Box::new(NoopPopup)
 }

--- a/crates/poltertype-popup/src/lib.rs
+++ b/crates/poltertype-popup/src/lib.rs
@@ -7,10 +7,13 @@
 //!   that grabs focus breaks the very keystrokes we exist to fix.
 //!   Wayland uses a layer-shell surface with
 //!   `keyboard_interactivity = None`, X11 an override-redirect window,
-//!   Windows `WS_EX_NOACTIVATE | WS_EX_TOPMOST | WS_EX_TOOLWINDOW`.
+//!   Windows `WS_EX_NOACTIVATE | WS_EX_TOPMOST | WS_EX_TOOLWINDOW`,
+//!   macOS a borderless `NSPanel` with `NonactivatingPanel`.
 //! * **Never log the words being shown**, same rule as the engine.
 //! * **Never block the caller.** `show` / `hide` enqueue and return;
-//!   all OS I/O happens on the popup's own thread.
+//!   all OS I/O happens on the popup's own thread (Linux/Windows) or
+//!   on the main dispatch queue (macOS — AppKit's rule; see
+//!   `docs/MACOS_POPUP.md`).
 //!
 //! Backends are *probed*, not chosen from a table of desktop names:
 //! layer-shell, then X11, then noop. That is why KDE worked the whole
@@ -25,20 +28,25 @@
 
 mod enums;
 mod factory;
+// The fallback for platforms and probes without an overlay path;
+// unused on macOS, where the one backend is infallible.
+#[cfg(not(target_os = "macos"))]
 mod noop;
 // The shared placement + renderer are consumed by every real backend.
-// Still gated, because macOS has none and compiling them there would
-// trip `-D dead_code` on that CI lane; add its target here when one
-// lands.
-#[cfg(any(target_os = "linux", windows))]
+// Still gated, because a platform with no backend compiling them would
+// trip `-D dead_code` on that CI lane; add new targets here as
+// backends land.
+#[cfg(any(target_os = "linux", windows, target_os = "macos"))]
 mod place;
-#[cfg(any(target_os = "linux", windows))]
+#[cfg(any(target_os = "linux", windows, target_os = "macos"))]
 mod render;
 mod traits;
 mod types;
 
 #[cfg(target_os = "linux")]
 mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
 #[cfg(windows)]
 mod windows;
 
@@ -47,5 +55,5 @@ pub use factory::create_popup;
 pub use traits::SuggestionPopup;
 pub use types::{PopupEntry, PopupModel};
 
-#[cfg(all(test, any(target_os = "linux", windows)))]
+#[cfg(all(test, any(target_os = "linux", windows, target_os = "macos")))]
 mod tests;

--- a/crates/poltertype-popup/src/macos/mod.rs
+++ b/crates/poltertype-popup/src/macos/mod.rs
@@ -1,0 +1,21 @@
+//! macOS backend for the suggestion tooltip.
+//!
+//! Same split as the other backends: [`panel`] holds every call into
+//! AppKit / Core Graphics, [`popup`] is the public handle and the
+//! decisions. The structural difference is threading: AppKit window
+//! objects may only be touched on the main thread, and the app's main
+//! thread belongs to the tao event loop — so instead of owning a
+//! thread this backend hops onto the main dispatch queue, and the
+//! state lives in a main-thread `thread_local!` (see
+//! `docs/MACOS_POPUP.md`).
+//!
+//! The focus guarantee is met the same way Windows meets it — by
+//! window configuration, not by runtime care: an `NSPanel` with
+//! `NSWindowStyleMask::NonactivatingPanel` cannot become key, so a
+//! click on a row never takes the keyboard away from the text the
+//! user is editing.
+
+mod panel;
+mod popup;
+
+pub use popup::MacosPopup;

--- a/crates/poltertype-popup/src/macos/panel.rs
+++ b/crates/poltertype-popup/src/macos/panel.rs
@@ -207,7 +207,10 @@ impl PanelState {
         let timeout = model.timeout;
         // Deliberately no word in this line — the tooltip's contents
         // are the user's text, and this crate logs none of it.
-        debug!(entries = model.entries.len(), scale, x, y, w, h, "tooltip shown");
+        debug!(
+            entries = model.entries.len(),
+            scale, x, y, w, h, "tooltip shown"
+        );
         self.shown = Some(Shown {
             model,
             rendered,
@@ -447,14 +450,12 @@ fn point_in_rect(point: NSPoint, rect: NSRect) -> bool {
 /// half-translated.
 fn mac_hint(hint: &str) -> String {
     hint.split('+')
-        .filter_map(|token| {
-            match token.trim().to_lowercase().as_str() {
-                "ctrl" | "control" => Some('⌃'),
-                "shift" => Some('⇧'),
-                "alt" | "option" => Some('⌥'),
-                "cmd" | "command" | "meta" | "super" | "win" => Some('⌘'),
-                _ => None,
-            }
+        .filter_map(|token| match token.trim().to_lowercase().as_str() {
+            "ctrl" | "control" => Some('⌃'),
+            "shift" => Some('⇧'),
+            "alt" | "option" => Some('⌥'),
+            "cmd" | "command" | "meta" | "super" | "win" => Some('⌘'),
+            _ => None,
         })
         .collect()
 }

--- a/crates/poltertype-popup/src/macos/panel.rs
+++ b/crates/poltertype-popup/src/macos/panel.rs
@@ -1,0 +1,535 @@
+//! The AppKit side of the macOS tooltip: a borderless, non-activating
+//! `NSPanel` whose content view's layer carries the rendered frame.
+//!
+//! Everything in this file runs on the main thread, dispatched here
+//! from the handle in [`super::popup`] via the main dispatch queue —
+//! AppKit's threading rule, and the reason this backend has no thread
+//! of its own. State lives in the `STATE` thread-local; every entry
+//! point re-acquires the main-thread marker rather than trusting the
+//! caller.
+//!
+//! ## Coordinate spaces
+//!
+//! Anchors arrive in Core Graphics / accessibility coordinates
+//! (global, top-left origin, y down) and all placement maths happens
+//! there, so the shared [`crate::place`] logic works unmodified. The
+//! single conversion to AppKit's bottom-left space happens when the
+//! panel frame is set: `appkit_y = primary_height - cg_y - height`.
+//!
+//! ## Focus
+//!
+//! `NSWindowStyleMask::NonactivatingPanel` is the whole "never steal
+//! focus" guarantee: the panel can be clicked (row hit-tests run in
+//! `mouseDown`) but can never become key, so the editor keeps the
+//! keyboard. `setReleasedWhenClosed(false)` matches the lifetime of
+//! every other object here: ours, for the process duration.
+
+use std::cell::RefCell;
+use std::sync::{Arc, OnceLock};
+
+use core_graphics::color_space::CGColorSpace;
+use core_graphics::data_provider::CGDataProvider;
+use core_graphics::display::CGDisplay;
+use core_graphics::image::{CGImage, CGImageAlphaInfo, CGImageByteOrderInfo};
+use crossbeam_channel::Sender;
+use dispatch2::{DispatchQueue, DispatchTime};
+use objc2::runtime::AnyObject;
+use objc2::{AnyThread, MainThreadOnly, define_class, msg_send, rc::Retained};
+use objc2_app_kit::{
+    NSBackingStoreType, NSColor, NSEvent, NSPanel, NSScreen, NSStatusWindowLevel, NSTrackingArea,
+    NSTrackingAreaOptions, NSView, NSWindowCollectionBehavior, NSWindowStyleMask,
+};
+use objc2_foundation::{MainThreadMarker, NSPoint, NSRect, NSSize};
+use tracing::{debug, warn};
+
+use crate::enums::{PopupAnchor, PopupUiEvent};
+use crate::render::{RenderedPopup, Renderer, hit_row};
+use crate::types::PopupModel;
+
+/// Popup bottom edge floats this many px above the anchor window's
+/// bottom edge (or the screen bottom). Matches the other backends.
+const BOTTOM_OFFSET: i32 = 96;
+
+/// The app halves of every `PopupUiEvent` flow back through this.
+/// Set once at construction; the panel outlives it.
+static EVENTS: OnceLock<Sender<PopupUiEvent>> = OnceLock::new();
+
+pub(super) fn register_events(events: Sender<PopupUiEvent>) {
+    // A second registration means a second popup handle — the tests do
+    // that; the first sender is as good as any.
+    let _ = EVENTS.set(events);
+}
+
+/// What is on screen right now.
+struct Shown {
+    model: PopupModel,
+    rendered: RenderedPopup,
+    /// Device scale the frame was rendered at (Retina = 2.0).
+    scale: f64,
+    hover: Option<usize>,
+}
+
+/// Panel + renderer + whatever is displayed. Main-thread only.
+struct PanelState {
+    panel: Retained<NSPanel>,
+    view: Retained<PopupView>,
+    renderer: Renderer,
+    shown: Option<Shown>,
+}
+
+thread_local! {
+    static STATE: RefCell<Option<PanelState>> = const { RefCell::new(None) };
+}
+
+/// Entry point for `show`. Creates the panel lazily on first use —
+/// `create_popup` runs before the tao event loop starts, so this (and
+/// everything else here) must survive being the first AppKit call the
+/// process makes on the main queue.
+pub(super) fn show_on_main(model: PopupModel) {
+    let Some(mtm) = MainThreadMarker::new() else {
+        warn!("suggestion popup: not on the main thread; dropping show");
+        return;
+    };
+    STATE.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        if slot.is_none() {
+            *slot = PanelState::create(mtm);
+            if slot.is_none() {
+                warn!("could not create the overlay panel; suggestions will not be shown");
+                return;
+            }
+        }
+        if let Some(state) = slot.as_mut() {
+            state.show(model, mtm);
+        }
+    });
+}
+
+/// Entry point for `hide`. Idempotent.
+pub(super) fn hide_on_main() {
+    STATE.with(|cell| {
+        if let Some(state) = cell.borrow_mut().as_mut() {
+            state.hide();
+        }
+    });
+}
+
+/// The self-hide timer firing. Stale timers (a newer offer replaced
+/// the one that scheduled them) match no generation and do nothing.
+fn timeout_fired(generation: u64) {
+    STATE.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        let Some(state) = slot.as_mut() else { return };
+        let Some(shown) = &state.shown else { return };
+        if shown.model.generation != generation {
+            return;
+        }
+        state.hide();
+        if let Some(events) = EVENTS.get() {
+            let _ = events.send(PopupUiEvent::TimedOut { generation });
+        }
+    });
+}
+
+impl PanelState {
+    fn create(mtm: MainThreadMarker) -> Option<Self> {
+        let panel = NSPanel::initWithContentRect_styleMask_backing_defer(
+            NSPanel::alloc(mtm),
+            NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1.0, 1.0)),
+            NSWindowStyleMask::Borderless | NSWindowStyleMask::NonactivatingPanel,
+            NSBackingStoreType::Buffered,
+            false,
+        );
+        panel.setLevel(NSStatusWindowLevel);
+        // Visible on every space, unmoved by space switches, out of the
+        // Cmd+Tab window cycle — the macOS spelling of WS_EX_TOOLWINDOW.
+        panel.setCollectionBehavior(
+            NSWindowCollectionBehavior::CanJoinAllSpaces
+                | NSWindowCollectionBehavior::Stationary
+                | NSWindowCollectionBehavior::IgnoresCycle,
+        );
+        panel.setOpaque(false);
+        panel.setBackgroundColor(Some(&NSColor::clearColor()));
+        panel.setHasShadow(false);
+        panel.setIgnoresMouseEvents(false);
+        // We create and own it; AppKit must not free it under us.
+        unsafe { panel.setReleasedWhenClosed(false) };
+
+        let view = PopupView::new(mtm);
+        panel.setContentView(Some(&view));
+
+        Some(Self {
+            panel,
+            view,
+            renderer: Renderer::new(),
+            shown: None,
+        })
+    }
+
+    /// Render `model`, work out where it goes, and put it on screen.
+    /// Mirrors `present` in the Windows backend.
+    fn show(&mut self, mut model: PopupModel, mtm: MainThreadMarker) {
+        // The hint arrives as a config string ("Ctrl+Shift"); show it
+        // the way macOS users read shortcuts.
+        model.accept_hint = model.accept_hint.map(|h| mac_hint(&h));
+        let scale = scale_at(mtm, &model.anchor);
+        let rendered = self.renderer.render(&model, None, scale as f32);
+        let w_px = rendered.pixmap.width() as f64;
+        let h_px = rendered.pixmap.height() as f64;
+        let (w, h) = (w_px / scale, h_px / scale);
+
+        let (x, y) = place(w, h, &model.anchor);
+        let Some(image) = cg_image(&rendered.pixmap) else {
+            warn!("could not build the CGImage; not showing the tooltip");
+            self.hide();
+            return;
+        };
+
+        self.view
+            .setFrame(NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(w, h)));
+        if let Some(layer) = self.view.layer() {
+            // Safety: the layer retains its contents; the CGImage
+            // outlives the call. CGImage is the documented contents
+            // type for CALayer despite the `id` signature.
+            unsafe { layer.setContents(Some(&*std::ptr::from_ref(&*image).cast::<AnyObject>())) };
+            layer.setContentsScale(scale);
+        }
+
+        // CG (top-left origin) → AppKit (bottom-left origin).
+        let appkit_y = primary_height(mtm) - y - h;
+        self.panel.setFrame_display(
+            NSRect::new(NSPoint::new(x, appkit_y), NSSize::new(w, h)),
+            true,
+        );
+        self.panel.orderFrontRegardless();
+
+        let generation = model.generation;
+        let timeout = model.timeout;
+        // Deliberately no word in this line — the tooltip's contents
+        // are the user's text, and this crate logs none of it.
+        debug!(entries = model.entries.len(), scale, x, y, w, h, "tooltip shown");
+        self.shown = Some(Shown {
+            model,
+            rendered,
+            scale,
+            hover: None,
+        });
+
+        let when = match DispatchTime::try_from(timeout) {
+            Ok(t) => t,
+            Err(()) => {
+                warn!("tooltip timeout out of dispatch range; showing without a timer");
+                return;
+            }
+        };
+        let _ = DispatchQueue::main().after(when, move || timeout_fired(generation));
+    }
+
+    fn hide(&mut self) {
+        self.panel.orderOut(None);
+        self.shown = None;
+    }
+
+    /// Re-render at the current hover state and push the new pixels.
+    fn redraw_hover(&mut self, hover: Option<usize>) {
+        let Some(shown) = &mut self.shown else { return };
+        if shown.hover == hover {
+            return;
+        }
+        shown.hover = hover;
+        let rendered = self
+            .renderer
+            .render(&shown.model, shown.hover, shown.scale as f32);
+        if let Some(image) = cg_image(&rendered.pixmap)
+            && let Some(layer) = self.view.layer()
+        {
+            // Safety: as in `show`.
+            unsafe { layer.setContents(Some(&*std::ptr::from_ref(&*image).cast::<AnyObject>())) };
+        }
+        shown.rendered = rendered;
+    }
+}
+
+/// A click on the panel. Accepts the row under the pointer, if any;
+/// a click on panel padding is ignored (same as the other backends).
+fn click_at(point: NSPoint) {
+    STATE.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        let Some(state) = slot.as_mut() else { return };
+        let Some(shown) = &state.shown else { return };
+        let s = shown.scale;
+        let Some(index) = hit_row(
+            &shown.rendered.rows,
+            (point.x * s) as f32,
+            (point.y * s) as f32,
+        ) else {
+            return;
+        };
+        let generation = shown.model.generation;
+        state.hide();
+        if let Some(events) = EVENTS.get() {
+            let _ = events.send(PopupUiEvent::Accepted { generation, index });
+        }
+    });
+}
+
+fn hover_at(point: Option<NSPoint>) {
+    STATE.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        let Some(state) = slot.as_mut() else { return };
+        let hover = point.and_then(|p| {
+            let shown = state.shown.as_ref()?;
+            hit_row(
+                &shown.rendered.rows,
+                (p.x * shown.scale) as f32,
+                (p.y * shown.scale) as f32,
+            )
+        });
+        state.redraw_hover(hover);
+    });
+}
+
+/// The rendered frame as a CGImage. `tiny_skia`'s premultiplied RGBA
+/// is `kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast`
+/// byte-for-byte — no channel swap, unlike the Windows backend.
+fn cg_image(pixmap: &tiny_skia::Pixmap) -> Option<CGImage> {
+    let (w, h) = (pixmap.width() as usize, pixmap.height() as usize);
+    if w == 0 || h == 0 {
+        return None;
+    }
+    let provider = CGDataProvider::from_buffer(Arc::new(pixmap.data().to_vec()));
+    let space = CGColorSpace::create_device_rgb();
+    let info = CGImageByteOrderInfo::CGImageByteOrder32Big as u32
+        | CGImageAlphaInfo::CGImageAlphaPremultipliedLast as u32;
+    Some(CGImage::new(
+        w,
+        h,
+        8,
+        32,
+        w * 4,
+        &space,
+        info,
+        &provider,
+        false,
+        0, // kCGRenderingIntentDefault
+    ))
+}
+
+/// Height of the primary screen — the flip reference between the CG
+/// and AppKit spaces.
+fn primary_height(mtm: MainThreadMarker) -> f64 {
+    NSScreen::screens(mtm)
+        .firstObject()
+        .map_or(0.0, |s| s.frame().size.height)
+}
+
+/// The scale the renderer should draw at for the anchor's screen.
+/// Asked per screen via `backingScaleFactor` — the macOS spelling of
+/// the Windows per-monitor DPI query.
+fn scale_at(mtm: MainThreadMarker, anchor: &PopupAnchor) -> f64 {
+    let (ax, ay) = anchor_point(anchor);
+    let primary_h = primary_height(mtm);
+    // Anchor in AppKit coordinates for the frame contains-point test.
+    let appkit = NSPoint::new(ax, primary_h - ay);
+    for screen in NSScreen::screens(mtm).iter() {
+        if point_in_rect(appkit, screen.frame()) {
+            return screen.backingScaleFactor();
+        }
+    }
+    1.0
+}
+
+/// A point on the display the tooltip is about to appear on (CG
+/// space), used to ask that display its scale.
+fn anchor_point(anchor: &PopupAnchor) -> (f64, f64) {
+    match *anchor {
+        PopupAnchor::Point { x, y, .. } => (x as f64, y as f64),
+        PopupAnchor::WindowRect {
+            x,
+            y,
+            width,
+            height,
+            ..
+        } => (
+            (x + width as i32 / 2) as f64,
+            (y + height as i32 / 2) as f64,
+        ),
+        PopupAnchor::ScreenBottom { .. } => {
+            let (vx, vy, vw, vh) = display_union();
+            (vx + vw / 2.0, vy + vh / 2.0)
+        }
+    }
+}
+
+/// The union of every active display's bounds, in CG global
+/// coordinates — the same role `GetSystemMetrics(SM_*VIRTUALSCREEN)`
+/// plays in the Windows backend.
+fn display_union() -> (f64, f64, f64, f64) {
+    let Ok(ids) = CGDisplay::active_displays() else {
+        let b = CGDisplay::main().bounds();
+        return (b.origin.x, b.origin.y, b.size.width, b.size.height);
+    };
+    let mut union: Option<(f64, f64, f64, f64)> = None;
+    for id in ids {
+        let b = CGDisplay::new(id).bounds();
+        union = Some(match union {
+            None => (b.origin.x, b.origin.y, b.size.width, b.size.height),
+            Some((x, y, w, h)) => {
+                let (x1, y1) = (x.min(b.origin.x), y.min(b.origin.y));
+                let (x2, y2) = (
+                    (x + w).max(b.origin.x + b.size.width),
+                    (y + h).max(b.origin.y + b.size.height),
+                );
+                (x1, y1, x2 - x1, y2 - y1)
+            }
+        });
+    }
+    union.unwrap_or_else(|| {
+        let b = CGDisplay::main().bounds();
+        (b.origin.x, b.origin.y, b.size.width, b.size.height)
+    })
+}
+
+/// Placement in CG coordinates: the shared side-picker around the
+/// caret for `Point`, centred on the anchor window with the bottom
+/// edge `BOTTOM_OFFSET` above its bottom for `WindowRect`; clamped to
+/// the display union either way. Mirrors `place` in the Windows
+/// backend.
+fn place(w: f64, h: f64, anchor: &PopupAnchor) -> (f64, f64) {
+    let (vx, vy, vw, vh) = display_union();
+    let (wi, hi) = (w.ceil() as i32, h.ceil() as i32);
+    let (px, py) = match *anchor {
+        PopupAnchor::Point { x, y, height, .. } => {
+            // `place_near_point` works in a 0-based space; shift the
+            // union's origin out and back so a left-hand or upper
+            // display (negative coordinates) is handled.
+            let (rx, ry) = crate::place::place_near_point(
+                x - vx as i32,
+                y - vy as i32,
+                y - vy as i32 + height as i32,
+                wi,
+                hi,
+                Some((vw as i32, vh as i32)),
+            );
+            (rx as f64 + vx, ry as f64 + vy)
+        }
+        PopupAnchor::WindowRect {
+            x,
+            y,
+            width,
+            height,
+            ..
+        } => (
+            x as f64 + (width as f64 - w) / 2.0,
+            y as f64 + height as f64 - BOTTOM_OFFSET as f64 - h,
+        ),
+        PopupAnchor::ScreenBottom { .. } => {
+            (vx + (vw - w) / 2.0, vy + vh - BOTTOM_OFFSET as f64 - h)
+        }
+    };
+    (
+        px.clamp(vx, (vx + vw - w).max(vx)),
+        py.clamp(vy, (vy + vh - h).max(vy)),
+    )
+}
+
+/// `NSMouseInRect` spelled in Rust — one less AppKit import.
+fn point_in_rect(point: NSPoint, rect: NSRect) -> bool {
+    point.x >= rect.origin.x
+        && point.x < rect.origin.x + rect.size.width
+        && point.y >= rect.origin.y
+        && point.y < rect.origin.y + rect.size.height
+}
+
+/// The accept-chord hint in macOS shortcut notation: the config's
+/// `"Ctrl+Shift"` reads as a Windows chord to a Mac user; the same
+/// keys are `⌃⇧` here. Unknown tokens are dropped rather than shown
+/// half-translated.
+fn mac_hint(hint: &str) -> String {
+    hint.split('+')
+        .filter_map(|token| {
+            match token.trim().to_lowercase().as_str() {
+                "ctrl" | "control" => Some('⌃'),
+                "shift" => Some('⇧'),
+                "alt" | "option" => Some('⌥'),
+                "cmd" | "command" | "meta" | "super" | "win" => Some('⌘'),
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+#[derive(Default)]
+struct PopupViewIvars;
+
+define_class!(
+    // Safety:
+    // - `NSView` has no subclassing requirements relevant here.
+    // - The class is main-thread-only, matching AppKit's rules, and
+    //   is never subclassed further.
+    #[unsafe(super = NSView)]
+    #[thread_kind = MainThreadOnly]
+    #[name = "PolterTypePopupView"]
+    #[ivars = PopupViewIvars]
+    struct PopupView;
+
+    impl PopupView {
+        // Top-down coordinates, so the shared hit-test works on the
+        // renderer's row rectangles without a flip.
+        #[unsafe(method(isFlipped))]
+        fn is_flipped(&self) -> bool {
+            true
+        }
+
+        #[unsafe(method(mouseDown:))]
+        fn mouse_down(&self, event: &NSEvent) {
+            let point = self.convertPoint_fromView(event.locationInWindow(), None);
+            click_at(point);
+        }
+
+        #[unsafe(method(mouseMoved:))]
+        fn mouse_moved(&self, event: &NSEvent) {
+            let point = self.convertPoint_fromView(event.locationInWindow(), None);
+            hover_at(Some(point));
+        }
+
+        #[unsafe(method(mouseExited:))]
+        fn mouse_exited(&self, _event: &NSEvent) {
+            hover_at(None);
+        }
+
+        #[unsafe(method(updateTrackingAreas))]
+        fn update_tracking_areas(&self) {
+            // Safety: chaining to super is required by AppKit.
+            let () = unsafe { msg_send![super(self), updateTrackingAreas] };
+            for area in self.trackingAreas().iter() {
+                self.removeTrackingArea(&area);
+            }
+            let area = unsafe {
+                NSTrackingArea::initWithRect_options_owner_userInfo(
+                    NSTrackingArea::alloc(),
+                    self.bounds(),
+                    NSTrackingAreaOptions::MouseEnteredAndExited
+                        | NSTrackingAreaOptions::MouseMoved
+                        | NSTrackingAreaOptions::InVisibleRect
+                        // The panel is never key; without this the
+                        // hover events would never fire.
+                        | NSTrackingAreaOptions::ActiveAlways,
+                    // Safety: same object pointer, retyped; the area
+                    // retains its owner.
+                    Some(&*std::ptr::from_ref(self).cast::<AnyObject>()),
+                    None,
+                )
+            };
+            self.addTrackingArea(&area);
+        }
+    }
+);
+
+impl PopupView {
+    fn new(mtm: MainThreadMarker) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(PopupViewIvars);
+        // Safety: standard NSView initialisation of our own subclass.
+        unsafe { msg_send![super(this), init] }
+    }
+}

--- a/crates/poltertype-popup/src/macos/popup.rs
+++ b/crates/poltertype-popup/src/macos/popup.rs
@@ -1,0 +1,45 @@
+//! macOS backend: a borderless, non-activating `NSPanel`.
+//!
+//! Unlike the other backends there is no popup thread — AppKit window
+//! objects belong to the main thread, which the tao event loop owns —
+//! so the handle below is zero-sized and every command hops onto the
+//! main dispatch queue. The fire-and-forget contract holds by
+//! construction: `exec_async` enqueues and returns, and the engine's
+//! hot path never touches AppKit. See `docs/MACOS_POPUP.md`.
+
+use crossbeam_channel::Sender;
+use dispatch2::DispatchQueue;
+
+use super::panel;
+use crate::enums::PopupUiEvent;
+use crate::traits::SuggestionPopup;
+use crate::types::PopupModel;
+
+/// Dispatching handle; the panel and all state live on the main
+/// thread inside [`panel`].
+pub struct MacosPopup;
+
+impl MacosPopup {
+    /// Cannot fail: the panel itself is created lazily on first
+    /// `show`, once the event loop is actually pumping the main queue
+    /// (`create_popup` runs before `event_loop.run`, so creating it
+    /// here would deadlock a synchronous hop and race an async one).
+    pub fn new(events: Sender<PopupUiEvent>) -> Self {
+        panel::register_events(events);
+        Self
+    }
+}
+
+impl SuggestionPopup for MacosPopup {
+    fn show(&self, model: PopupModel) {
+        DispatchQueue::main().exec_async(move || panel::show_on_main(model));
+    }
+
+    fn hide(&self) {
+        DispatchQueue::main().exec_async(panel::hide_on_main);
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "macos-nspanel-nonactivating"
+    }
+}

--- a/docs/MACOS_POPUP.md
+++ b/docs/MACOS_POPUP.md
@@ -1,0 +1,165 @@
+# macOS suggestion tooltip — spec
+
+Status: draft → implemented (branch `feat/macos-popup`).
+Tracks the "macOS | noop today" row in `crates/poltertype-popup/src/lib.rs`.
+
+## Goal
+
+Feature parity with the Windows/Linux suggestion tooltip on macOS:
+the popup near the text being typed, spelling variants as clickable
+rows, keyboard accept chord unchanged (engine-side, already
+cross-platform), click-to-accept, hover highlight, self-hide timeout.
+
+## Why it was missing
+
+Two independent gaps, both ending in a noop:
+
+1. `poltertype-popup` had no macOS backend — `create_for_platform`
+   fell into the `#[cfg(not(any(linux, windows)))]` arm returning
+   `NoopPopup`.
+2. `poltertype-input`'s focus tracker had no macOS implementation
+   (`NoopFocusTracker`), so even with a popup the anchor would always
+   degrade to `ScreenBottom`.
+
+This spec covers both.
+
+## Non-negotiable invariants (from the crate docs)
+
+- **Never take keyboard focus.** The user is mid-typing.
+- **Never log the words being shown.**
+- **The engine's hot path never blocks on window-system I/O** —
+  `show`/`hide` are fire-and-forget.
+- `#[cfg(target_os)]` stays inside the platform-island crates
+  (`poltertype-popup`, `poltertype-input`).
+
+## Design: the panel (`poltertype-popup/src/macos/`)
+
+### Where the Windows/Linux guarantees map on macOS
+
+| Guarantee | Windows | macOS |
+|---|---|---|
+| Never activated | `WS_EX_NOACTIVATE` | `NSPanel` + `NSWindowStyleMask.NonactivatingPanel` |
+| Above the focused app | `WS_EX_TOPMOST` | `NSStatusWindowLevel` |
+| Invisible to app switcher | `WS_EX_TOOLWINDOW` | `collectionBehavior`: `canJoinAllSpaces | stationary | ignoresCycle`; app is `LSUIElement` |
+| Per-pixel alpha panel | `WS_EX_LAYERED` + `UpdateLayeredWindow` | borderless non-opaque window, pixels via `CALayer.contents` |
+| Click without focus steal | hit-test in message loop | `mouseDown` on the content view — a non-activating panel delivers clicks without moving key focus |
+
+### Threading model — different from Windows/Linux, deliberately
+
+AppKit window objects may only be touched on the main thread, and the
+app's main thread is owned by the tao event loop (`NSApplication`
+runloop, which also drains the GCD main queue). So unlike the other
+backends there is **no popup thread**:
+
+- `MacosPopup` is a zero-sized handle; `show(model)` / `hide()` wrap
+  the command in a closure and `dispatch2::DispatchQueue::main()
+  .exec_async(...)` it. Fire-and-forget, engine never blocks — the
+  invariant holds by construction.
+- All state (panel, renderer, current model, row hit-boxes, deadline)
+  lives in a main-thread `thread_local! RefCell<Option<PanelState>>`.
+- Rendering (the shared CPU renderer in `crate::render`) runs inside
+  the dispatched closure on the main thread. It is a ≤ 340 px panel
+  of ≤ 9 rows — single-digit milliseconds, once per offer; not an
+  animation path.
+- The timeout is `DispatchQueue::main().exec_after(timeout, …)`
+  guarded by the engine generation stamp; a stale timer fires into a
+  generation mismatch and does nothing.
+- Clicks/hover arrive as `NSView` callbacks on the main thread:
+  hit-test against the stored row rects, send `PopupUiEvent` over the
+  channel, hide via `orderOut`.
+
+Panel creation is also dispatched async at `try_new` — `create_popup`
+is called *before* `event_loop.run()`, so a synchronous hop to the
+main queue would deadlock; async enqueue is correct because the main
+queue is FIFO and any `show` dispatch lands after creation.
+
+### Pixels
+
+`crate::render` produces premultiplied RGBA — exactly
+`kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast`, no channel
+swap needed. The frame becomes a `CGImage` set as the content view's
+layer `contents` with `contentsScale = backingScaleFactor` of the
+screen the anchor lands on (Retina = 2.0, matching the Windows
+per-monitor DPI path).
+
+### Coordinates
+
+macOS has two global spaces. We standardise on the **Core Graphics /
+AX space (top-left origin, y down, logical points)** for everything
+internal — anchors arrive that way from the AX focus tracker, and
+`CGDisplay` bounds/union drive placement via the shared
+`crate::place::place_near_point`. The single conversion to AppKit's
+bottom-left space happens at `setFrame` time:
+`appkit_y = primary_screen_height − cg_y − height`.
+
+Placement mirrors the Windows backend: `Point` → shared side-picker
+above/below/right/left the caret; `WindowRect` → bottom-centre, 96 px
+above the window's bottom edge; `ScreenBottom` → bottom-centre of the
+union; all clamped to the display union.
+
+### Subclassing
+
+One `objc2::define_class!` NSView subclass (`PopupView`) with ivars
+for the event channel, the current row rects (logical px), and the
+generation. Overrides: `isFlipped` (top-down coordinates so the shared
+hit-test works unmodified), `mouseDown`, `mouseMoved`, `mouseExited`,
+`updateTrackingAreas` (a visible-rect tracking area — borderless
+windows get no motion events otherwise).
+
+## Design: the focus tracker (`poltertype-input/src/focus/macos_impl.rs`)
+
+Raw FFI to HIServices (`ApplicationServices` framework), same pattern
+as the existing `macos/listener.rs` FFI glue — no new crate deps
+beyond `libc` (for `proc_pidpath`):
+
+- `AXUIElementCreateSystemWide` → `kAXFocusedApplicationAttribute`
+  → `AXUIElementGetPid` + `proc_pidpath` ⇒ `focused_exe`.
+- Focused app element → `kAXFocusedWindowAttribute` →
+  `kAXPositionAttribute` / `kAXSizeAttribute` (AXValue-wrapped
+  `CGPoint`/`CGSize`) ⇒ `focused_window_geometry`. `output`/`output_*`
+  are `None`/`0` — that field is Wayland-only by contract.
+- System-wide `kAXFocusedUIElementAttribute` →
+  `kAXSelectedTextRangeAttribute` (AXValue `CFRange`) → parameterized
+  `kAXBoundsForRangeParameterizedAttribute` ⇒ caret `CGRect` in global
+  CG coordinates; converted to window-relative for `CaretHint`
+  (`age = 0` — it is a live query, not a cached sample).
+
+Accessibility permission is already a hard requirement of the app
+(the `CGEventTap` listener needs it), so these calls either work or
+return `kAXErrorAPIDisabled`, which we map to `None` — the anchor
+chain then degrades exactly as it does on GNOME Wayland.
+
+Every AX object is `CFRelease`d; no ObjC objects cross threads
+(the tracker methods are called on the engine thread and are
+self-contained).
+
+## Files touched
+
+- `crates/poltertype-popup/Cargo.toml` — macOS target deps:
+  `objc2 0.6`, `objc2-foundation 0.3`, `objc2-app-kit 0.3`,
+  `block2 0.6`, `dispatch2 0.3`, `core-graphics 0.25`
+  (all already in the lockfile via tao / poltertype-input).
+- `crates/poltertype-popup/src/macos/{mod,panel,popup}.rs` — new.
+- `crates/poltertype-popup/src/lib.rs` — `mod macos`, platform table,
+  `place`/`render` cfg widened to `any(linux, windows, macos)`.
+- `crates/poltertype-popup/src/factory.rs` — macOS arm.
+- `crates/poltertype-input/src/focus/{mod,factory}.rs` — macOS arm.
+- `crates/poltertype-input/src/focus/macos_impl.rs` — new.
+- `crates/poltertype-input/Cargo.toml` — `libc` for macOS.
+
+## Verification
+
+- `cargo check --target x86_64-apple-darwin -p poltertype-popup -p poltertype-input`
+  (the macOS CI lane does the same on aarch64).
+- `cargo clippy --workspace --all-targets` + `cargo test --workspace`
+  on Linux — no regressions outside the macOS islands.
+- Runtime verification on a Mac: typing a known typo shows the panel
+  above the caret; click accepts; timeout self-hides; focus never
+  leaves the editor (type-through test).
+
+## Explicitly out of scope
+
+- Trackpad/mouse-wheel scrolling inside the panel (≤ 9 rows fit).
+- Caret anchoring in apps that expose no AX text attributes — falls
+  back to window-bottom, by design.
+- Animated show/hide.

--- a/docs/MACOS_POPUP.md
+++ b/docs/MACOS_POPUP.md
@@ -1,6 +1,7 @@
 # macOS suggestion tooltip — spec
 
-Status: draft → implemented (branch `feat/macos-popup`).
+Status: implemented (branch `feat/macos-popup`), hardware-verified
+2026-08-10 (TextEdit + Chrome, Intel Mac Pro, macOS 15.7).
 Tracks the "macOS | noop today" row in `crates/poltertype-popup/src/lib.rs`.
 
 ## Goal
@@ -109,29 +110,49 @@ windows get no motion events otherwise).
 ## Design: the focus tracker (`poltertype-input/src/focus/macos_impl.rs`)
 
 Raw FFI to HIServices (`ApplicationServices` framework), same pattern
-as the existing `macos/listener.rs` FFI glue — no new crate deps
-beyond `libc` (for `proc_pidpath`):
+as the existing `macos/listener.rs` FFI glue. Hardware findings that
+shaped it (2026-08-10, verified with a signed probe binary):
 
-- `AXUIElementCreateSystemWide` → `kAXFocusedApplicationAttribute`
-  → `AXUIElementGetPid` + `proc_pidpath` ⇒ `focused_exe`.
-- Focused app element → `kAXFocusedWindowAttribute` →
-  `kAXPositionAttribute` / `kAXSizeAttribute` (AXValue-wrapped
-  `CGPoint`/`CGSize`) ⇒ `focused_window_geometry`. `output`/`output_*`
-  are `None`/`0` — that field is Wayland-only by contract.
-- System-wide `kAXFocusedUIElementAttribute` →
-  `kAXSelectedTextRangeAttribute` (AXValue `CFRange`) → parameterized
-  `kAXBoundsForRangeParameterizedAttribute` ⇒ caret `CGRect` in global
-  CG coordinates; converted to window-relative for `CaretHint`
-  (`age = 0` — it is a live query, not a cached sample).
+- **`AXUIElementCreateSystemWide` is not trustworthy.** Its
+  `kAXFocusedApplication` answered `kAXErrorCannotComplete` ~always,
+  while `AXUIElementCreateApplication(frontmost_pid)` (pid via
+  `NSWorkspace.frontmostApplication`) answers instantly. Everything
+  hangs off the pid-built app element. (SuperDictate instead retries
+  the system-wide path; both validate that the *focused-element* query
+  needs a retry on transient `cannotComplete`/`noValue` — 3×40 ms.)
+- **Caret bounds are junk in Chrome and Terminal.** Both
+  `AXBoundsForRange` and the marker-range pair
+  (`AXBoundsForTextMarkerRange`, tried first — WebKit implements it
+  better) return zero-size rects at the web area's origin or points
+  past the window's bottom edge. Native apps (TextEdit, loginwindow)
+  return real thin caret rects. So: caret answers are *validated*
+  (finite, one-line height cap, thin-width cap, must intersect the
+  element's frame ±24 pt); junk falls back to the focused element's
+  own frame when its role is a text widget (`AXTextField`/`AXTextArea`
+  /`AXComboBox`) — exact for the omnibox, field-level for web inputs.
+  The `AXManualAccessibility`/`AXEnhancedUserInterface` toggles that
+  would make Chrome compute real carets were considered and rejected:
+  they mutate another process's global state from a typing utility.
+- **AX queries get a 0.3 s messaging timeout** — this runs on the tao
+  event loop at tooltip-show time, and a hung target app must not
+  freeze it for the multi-second AX default.
 
 Accessibility permission is already a hard requirement of the app
 (the `CGEventTap` listener needs it), so these calls either work or
-return `kAXErrorAPIDisabled`, which we map to `None` — the anchor
-chain then degrades exactly as it does on GNOME Wayland.
+return an AX error, which maps to `None` — the anchor chain then
+degrades exactly as it does on GNOME Wayland.
 
-Every AX object is `CFRelease`d; no ObjC objects cross threads
-(the tracker methods are called on the engine thread and are
-self-contained).
+## Verified on hardware (2026-08-10)
+
+- TextEdit: caret anchor = the real text caret; 4/4 click-accepts and
+  chord accepts replaced the word cleanly.
+- Chrome omnibox: anchor lands under the address bar.
+- Burst pacing: before `KEY_STEP`, one backspace in a burst was
+  observably lost/gained at the delete→replay seam ("Привт пприват",
+  eaten leading separator); after, 4/4 clean.
+- Screenshot capture note: `screencapture`/`CGWindowListCreateImage`
+  only see the *active* Space; the panel's on-screen geometry was
+  confirmed via `CGWindowListCopyWindowInfo` instead.
 
 ## Files touched
 


### PR DESCRIPTION
## Summary

macOS previously used `NoopPopup`, so spelling and layout suggestions
were not displayed. This PR adds the macOS implementation and restores
feature parity with Windows and Linux.

## Changes

- Add a borderless, non-activating `NSPanel` popup backend for macOS.
- Render popup contents through `CGImage`/`CALayer` with Retina scaling.
- Support hover, click-to-accept, timeout dismissal, and generation checks.
- Dispatch AppKit operations through the main dispatch queue.
- Add macOS Accessibility focus tracking:
  - focused application and window geometry;
  - native caret detection;
  - validated AX caret bounds;
  - fallback to the focused text-field frame for Chrome, Terminal, and
    other applications with unreliable caret APIs.
- Retry transient Accessibility focus-query failures.
- Pace macOS CGEvent correction bursts to prevent dropped or duplicated
  characters during replacement.
- Display shortcut hints using macOS notation, for example `⌃⇧`.
- Prevent `cosmic-text`/`fontdb` debug logs from exposing shaped user text.

## Verification

Tested on Intel Mac Pro running macOS 15.7:

- Popup placement near TextEdit caret.
- Popup placement near the Chrome address bar.
- Keyboard acceptance.
- Click acceptance.
- Multiple consecutive replacements without losing the separator or
  duplicating the first replacement character.
- `cargo fmt --all -- --check`.
- `cargo clippy --target x86_64-apple-darwin -p poltertype-input -p poltertype-popup --all-targets -- -D warnings`.

This branch is based directly on upstream `v0.14.4` and does not include
fork-specific updater or release changes.